### PR TITLE
FIX min PHPStan requirement to 1.3

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -5,7 +5,7 @@
   "type": "phpstan-extension",
   "require": {
     "php": "^8",
-    "phpstan/phpstan": "^1.0",
+    "phpstan/phpstan": "^1.3",
     "dave-liddament/php-language-extensions": "^0.1.0"
   },
   "require-dev": {

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "a568f4ea82f0038237b68c756fbba1f6",
+    "content-hash": "43bac8598035a7d102fa2684e3508b5e",
     "packages": [
         {
             "name": "dave-liddament/php-language-extensions",
@@ -54,16 +54,16 @@
         },
         {
             "name": "phpstan/phpstan",
-            "version": "1.5.7",
+            "version": "1.6.8",
             "source": {
                 "type": "git",
                 "url": "https://github.com/phpstan/phpstan.git",
-                "reference": "7fb7e2e1e9f3d59a26a413b2d3d5e47f0edb75ac"
+                "reference": "d76498c5531232cb8386ceb6004f7e013138d3ba"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/phpstan/phpstan/zipball/7fb7e2e1e9f3d59a26a413b2d3d5e47f0edb75ac",
-                "reference": "7fb7e2e1e9f3d59a26a413b2d3d5e47f0edb75ac",
+                "url": "https://api.github.com/repos/phpstan/phpstan/zipball/d76498c5531232cb8386ceb6004f7e013138d3ba",
+                "reference": "d76498c5531232cb8386ceb6004f7e013138d3ba",
                 "shasum": ""
             },
             "require": {
@@ -89,7 +89,7 @@
             "description": "PHPStan - PHP Static Analysis Tool",
             "support": {
                 "issues": "https://github.com/phpstan/phpstan/issues",
-                "source": "https://github.com/phpstan/phpstan/tree/1.5.7"
+                "source": "https://github.com/phpstan/phpstan/tree/1.6.8"
             },
             "funding": [
                 {
@@ -109,7 +109,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2022-04-20T12:20:27+00:00"
+            "time": "2022-05-10T06:54:21+00:00"
         }
     ],
     "packages-dev": [


### PR DESCRIPTION
This is needed as PHPStan 1.3 is required for attributes to be read correctly (I assume this is down to the 1.3 upgrading to BetterReflection 5.0.0