### PR TITLE
ADD NamespaceVisibility and CallableFrom 

### DIFF
--- a/.php-cs-fixer.php
+++ b/.php-cs-fixer.php
@@ -23,6 +23,7 @@ return $config
             'phpdoc_align' => false,
             'phpdoc_to_comment' => false,
             'native_function_invocation' => false,
+            'phpdoc_separation' => false,
         ]
     )
     ->setFinder($finder)

--- a/composer.json
+++ b/composer.json
@@ -6,7 +6,7 @@
   "require": {
     "php": "^8",
     "phpstan/phpstan": "^1.3",
-    "dave-liddament/php-language-extensions": "^0.2.1"
+    "dave-liddament/php-language-extensions": "dev-feature/updates"
   },
   "require-dev": {
     "phpunit/phpunit": "^9.0",

--- a/composer.lock
+++ b/composer.lock
@@ -4,20 +4,20 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "0e055e95e35f76b9015b961697bda9ea",
+    "content-hash": "78ea82a387076c0757c93415425cb199",
     "packages": [
         {
             "name": "dave-liddament/php-language-extensions",
-            "version": "0.2.1",
+            "version": "dev-feature/updates",
             "source": {
                 "type": "git",
                 "url": "https://github.com/DaveLiddament/php-language-extensions.git",
-                "reference": "aa2f63225b1f5c5feb85c1b8736b46f375c73d7c"
+                "reference": "4661a700b25f46e5be8f9d11f288a3bc9d1b7475"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/DaveLiddament/php-language-extensions/zipball/aa2f63225b1f5c5feb85c1b8736b46f375c73d7c",
-                "reference": "aa2f63225b1f5c5feb85c1b8736b46f375c73d7c",
+                "url": "https://api.github.com/repos/DaveLiddament/php-language-extensions/zipball/4661a700b25f46e5be8f9d11f288a3bc9d1b7475",
+                "reference": "4661a700b25f46e5be8f9d11f288a3bc9d1b7475",
                 "shasum": ""
             },
             "require": {
@@ -54,22 +54,22 @@
             ],
             "support": {
                 "issues": "https://github.com/DaveLiddament/php-language-extensions/issues",
-                "source": "https://github.com/DaveLiddament/php-language-extensions/tree/0.2.1"
+                "source": "https://github.com/DaveLiddament/php-language-extensions/tree/feature/updates"
             },
-            "time": "2022-05-31T09:24:08+00:00"
+            "time": "2022-08-14T04:21:35+00:00"
         },
         {
             "name": "phpstan/phpstan",
-            "version": "1.6.8",
+            "version": "1.8.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/phpstan/phpstan.git",
-                "reference": "d76498c5531232cb8386ceb6004f7e013138d3ba"
+                "reference": "c53312ecc575caf07b0e90dee43883fdf90ca67c"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/phpstan/phpstan/zipball/d76498c5531232cb8386ceb6004f7e013138d3ba",
-                "reference": "d76498c5531232cb8386ceb6004f7e013138d3ba",
+                "url": "https://api.github.com/repos/phpstan/phpstan/zipball/c53312ecc575caf07b0e90dee43883fdf90ca67c",
+                "reference": "c53312ecc575caf07b0e90dee43883fdf90ca67c",
                 "shasum": ""
             },
             "require": {
@@ -95,7 +95,7 @@
             "description": "PHPStan - PHP Static Analysis Tool",
             "support": {
                 "issues": "https://github.com/phpstan/phpstan/issues",
-                "source": "https://github.com/phpstan/phpstan/tree/1.6.8"
+                "source": "https://github.com/phpstan/phpstan/tree/1.8.2"
             },
             "funding": [
                 {
@@ -115,7 +115,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2022-05-10T06:54:21+00:00"
+            "time": "2022-07-20T09:57:31+00:00"
         }
     ],
     "packages-dev": [
@@ -339,16 +339,16 @@
         },
         {
             "name": "doctrine/annotations",
-            "version": "1.13.2",
+            "version": "1.13.3",
             "source": {
                 "type": "git",
                 "url": "https://github.com/doctrine/annotations.git",
-                "reference": "5b668aef16090008790395c02c893b1ba13f7e08"
+                "reference": "648b0343343565c4a056bfc8392201385e8d89f0"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/doctrine/annotations/zipball/5b668aef16090008790395c02c893b1ba13f7e08",
-                "reference": "5b668aef16090008790395c02c893b1ba13f7e08",
+                "url": "https://api.github.com/repos/doctrine/annotations/zipball/648b0343343565c4a056bfc8392201385e8d89f0",
+                "reference": "648b0343343565c4a056bfc8392201385e8d89f0",
                 "shasum": ""
             },
             "require": {
@@ -360,9 +360,10 @@
             "require-dev": {
                 "doctrine/cache": "^1.11 || ^2.0",
                 "doctrine/coding-standard": "^6.0 || ^8.1",
-                "phpstan/phpstan": "^0.12.20",
+                "phpstan/phpstan": "^1.4.10 || ^1.8.0",
                 "phpunit/phpunit": "^7.5 || ^8.0 || ^9.1.5",
-                "symfony/cache": "^4.4 || ^5.2"
+                "symfony/cache": "^4.4 || ^5.2",
+                "vimeo/psalm": "^4.10"
             },
             "type": "library",
             "autoload": {
@@ -405,9 +406,9 @@
             ],
             "support": {
                 "issues": "https://github.com/doctrine/annotations/issues",
-                "source": "https://github.com/doctrine/annotations/tree/1.13.2"
+                "source": "https://github.com/doctrine/annotations/tree/1.13.3"
             },
-            "time": "2021-08-05T19:00:23+00:00"
+            "time": "2022-07-02T10:48:51+00:00"
         },
         {
             "name": "doctrine/instantiator",
@@ -557,16 +558,16 @@
         },
         {
             "name": "friendsofphp/php-cs-fixer",
-            "version": "v3.8.0",
+            "version": "v3.10.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/FriendsOfPHP/PHP-CS-Fixer.git",
-                "reference": "cbad1115aac4b5c3c5540e7210d3c9fba2f81fa3"
+                "reference": "76d7da666e66d83a1dc27a9d1c625c80cc4ac1fe"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/FriendsOfPHP/PHP-CS-Fixer/zipball/cbad1115aac4b5c3c5540e7210d3c9fba2f81fa3",
-                "reference": "cbad1115aac4b5c3c5540e7210d3c9fba2f81fa3",
+                "url": "https://api.github.com/repos/FriendsOfPHP/PHP-CS-Fixer/zipball/76d7da666e66d83a1dc27a9d1c625c80cc4ac1fe",
+                "reference": "76d7da666e66d83a1dc27a9d1c625c80cc4ac1fe",
                 "shasum": ""
             },
             "require": {
@@ -576,7 +577,7 @@
                 "ext-json": "*",
                 "ext-tokenizer": "*",
                 "php": "^7.4 || ^8.0",
-                "php-cs-fixer/diff": "^2.0",
+                "sebastian/diff": "^4.0",
                 "symfony/console": "^5.4 || ^6.0",
                 "symfony/event-dispatcher": "^5.4 || ^6.0",
                 "symfony/filesystem": "^5.4 || ^6.0",
@@ -634,7 +635,7 @@
             "description": "A tool to automatically fix PHP code style",
             "support": {
                 "issues": "https://github.com/FriendsOfPHP/PHP-CS-Fixer/issues",
-                "source": "https://github.com/FriendsOfPHP/PHP-CS-Fixer/tree/v3.8.0"
+                "source": "https://github.com/FriendsOfPHP/PHP-CS-Fixer/tree/v3.10.0"
             },
             "funding": [
                 {
@@ -642,7 +643,7 @@
                     "type": "github"
                 }
             ],
-            "time": "2022-03-18T17:20:59+00:00"
+            "time": "2022-08-17T22:13:10+00:00"
         },
         {
             "name": "myclabs/deep-copy",
@@ -705,16 +706,16 @@
         },
         {
             "name": "nikic/php-parser",
-            "version": "v4.13.2",
+            "version": "v4.14.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/nikic/PHP-Parser.git",
-                "reference": "210577fe3cf7badcc5814d99455df46564f3c077"
+                "reference": "34bea19b6e03d8153165d8f30bba4c3be86184c1"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/nikic/PHP-Parser/zipball/210577fe3cf7badcc5814d99455df46564f3c077",
-                "reference": "210577fe3cf7badcc5814d99455df46564f3c077",
+                "url": "https://api.github.com/repos/nikic/PHP-Parser/zipball/34bea19b6e03d8153165d8f30bba4c3be86184c1",
+                "reference": "34bea19b6e03d8153165d8f30bba4c3be86184c1",
                 "shasum": ""
             },
             "require": {
@@ -755,9 +756,9 @@
             ],
             "support": {
                 "issues": "https://github.com/nikic/PHP-Parser/issues",
-                "source": "https://github.com/nikic/PHP-Parser/tree/v4.13.2"
+                "source": "https://github.com/nikic/PHP-Parser/tree/v4.14.0"
             },
-            "time": "2021-11-30T19:35:32+00:00"
+            "time": "2022-05-31T20:59:12+00:00"
         },
         {
             "name": "phar-io/manifest",
@@ -871,58 +872,6 @@
             "time": "2022-02-21T01:04:05+00:00"
         },
         {
-            "name": "php-cs-fixer/diff",
-            "version": "v2.0.2",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/PHP-CS-Fixer/diff.git",
-                "reference": "29dc0d507e838c4580d018bd8b5cb412474f7ec3"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/PHP-CS-Fixer/diff/zipball/29dc0d507e838c4580d018bd8b5cb412474f7ec3",
-                "reference": "29dc0d507e838c4580d018bd8b5cb412474f7ec3",
-                "shasum": ""
-            },
-            "require": {
-                "php": "^5.6 || ^7.0 || ^8.0"
-            },
-            "require-dev": {
-                "phpunit/phpunit": "^5.7.23 || ^6.4.3 || ^7.0",
-                "symfony/process": "^3.3"
-            },
-            "type": "library",
-            "autoload": {
-                "classmap": [
-                    "src/"
-                ]
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "BSD-3-Clause"
-            ],
-            "authors": [
-                {
-                    "name": "Sebastian Bergmann",
-                    "email": "sebastian@phpunit.de"
-                },
-                {
-                    "name": "Kore Nordmann",
-                    "email": "mail@kore-nordmann.de"
-                }
-            ],
-            "description": "sebastian/diff v3 backport support for PHP 5.6+",
-            "homepage": "https://github.com/PHP-CS-Fixer",
-            "keywords": [
-                "diff"
-            ],
-            "support": {
-                "issues": "https://github.com/PHP-CS-Fixer/diff/issues",
-                "source": "https://github.com/PHP-CS-Fixer/diff/tree/v2.0.2"
-            },
-            "time": "2020-10-14T08:32:19+00:00"
-        },
-        {
             "name": "php-parallel-lint/php-parallel-lint",
             "version": "v1.3.2",
             "source": {
@@ -980,251 +929,24 @@
             "time": "2022-02-21T12:50:22+00:00"
         },
         {
-            "name": "phpdocumentor/reflection-common",
-            "version": "2.2.0",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/phpDocumentor/ReflectionCommon.git",
-                "reference": "1d01c49d4ed62f25aa84a747ad35d5a16924662b"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/phpDocumentor/ReflectionCommon/zipball/1d01c49d4ed62f25aa84a747ad35d5a16924662b",
-                "reference": "1d01c49d4ed62f25aa84a747ad35d5a16924662b",
-                "shasum": ""
-            },
-            "require": {
-                "php": "^7.2 || ^8.0"
-            },
-            "type": "library",
-            "extra": {
-                "branch-alias": {
-                    "dev-2.x": "2.x-dev"
-                }
-            },
-            "autoload": {
-                "psr-4": {
-                    "phpDocumentor\\Reflection\\": "src/"
-                }
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "MIT"
-            ],
-            "authors": [
-                {
-                    "name": "Jaap van Otterdijk",
-                    "email": "opensource@ijaap.nl"
-                }
-            ],
-            "description": "Common reflection classes used by phpdocumentor to reflect the code structure",
-            "homepage": "http://www.phpdoc.org",
-            "keywords": [
-                "FQSEN",
-                "phpDocumentor",
-                "phpdoc",
-                "reflection",
-                "static analysis"
-            ],
-            "support": {
-                "issues": "https://github.com/phpDocumentor/ReflectionCommon/issues",
-                "source": "https://github.com/phpDocumentor/ReflectionCommon/tree/2.x"
-            },
-            "time": "2020-06-27T09:03:43+00:00"
-        },
-        {
-            "name": "phpdocumentor/reflection-docblock",
-            "version": "5.3.0",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/phpDocumentor/ReflectionDocBlock.git",
-                "reference": "622548b623e81ca6d78b721c5e029f4ce664f170"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/phpDocumentor/ReflectionDocBlock/zipball/622548b623e81ca6d78b721c5e029f4ce664f170",
-                "reference": "622548b623e81ca6d78b721c5e029f4ce664f170",
-                "shasum": ""
-            },
-            "require": {
-                "ext-filter": "*",
-                "php": "^7.2 || ^8.0",
-                "phpdocumentor/reflection-common": "^2.2",
-                "phpdocumentor/type-resolver": "^1.3",
-                "webmozart/assert": "^1.9.1"
-            },
-            "require-dev": {
-                "mockery/mockery": "~1.3.2",
-                "psalm/phar": "^4.8"
-            },
-            "type": "library",
-            "extra": {
-                "branch-alias": {
-                    "dev-master": "5.x-dev"
-                }
-            },
-            "autoload": {
-                "psr-4": {
-                    "phpDocumentor\\Reflection\\": "src"
-                }
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "MIT"
-            ],
-            "authors": [
-                {
-                    "name": "Mike van Riel",
-                    "email": "me@mikevanriel.com"
-                },
-                {
-                    "name": "Jaap van Otterdijk",
-                    "email": "account@ijaap.nl"
-                }
-            ],
-            "description": "With this component, a library can provide support for annotations via DocBlocks or otherwise retrieve information that is embedded in a DocBlock.",
-            "support": {
-                "issues": "https://github.com/phpDocumentor/ReflectionDocBlock/issues",
-                "source": "https://github.com/phpDocumentor/ReflectionDocBlock/tree/5.3.0"
-            },
-            "time": "2021-10-19T17:43:47+00:00"
-        },
-        {
-            "name": "phpdocumentor/type-resolver",
-            "version": "1.6.1",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/phpDocumentor/TypeResolver.git",
-                "reference": "77a32518733312af16a44300404e945338981de3"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/phpDocumentor/TypeResolver/zipball/77a32518733312af16a44300404e945338981de3",
-                "reference": "77a32518733312af16a44300404e945338981de3",
-                "shasum": ""
-            },
-            "require": {
-                "php": "^7.2 || ^8.0",
-                "phpdocumentor/reflection-common": "^2.0"
-            },
-            "require-dev": {
-                "ext-tokenizer": "*",
-                "psalm/phar": "^4.8"
-            },
-            "type": "library",
-            "extra": {
-                "branch-alias": {
-                    "dev-1.x": "1.x-dev"
-                }
-            },
-            "autoload": {
-                "psr-4": {
-                    "phpDocumentor\\Reflection\\": "src"
-                }
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "MIT"
-            ],
-            "authors": [
-                {
-                    "name": "Mike van Riel",
-                    "email": "me@mikevanriel.com"
-                }
-            ],
-            "description": "A PSR-5 based resolver of Class names, Types and Structural Element Names",
-            "support": {
-                "issues": "https://github.com/phpDocumentor/TypeResolver/issues",
-                "source": "https://github.com/phpDocumentor/TypeResolver/tree/1.6.1"
-            },
-            "time": "2022-03-15T21:29:03+00:00"
-        },
-        {
-            "name": "phpspec/prophecy",
-            "version": "v1.15.0",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/phpspec/prophecy.git",
-                "reference": "bbcd7380b0ebf3961ee21409db7b38bc31d69a13"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/phpspec/prophecy/zipball/bbcd7380b0ebf3961ee21409db7b38bc31d69a13",
-                "reference": "bbcd7380b0ebf3961ee21409db7b38bc31d69a13",
-                "shasum": ""
-            },
-            "require": {
-                "doctrine/instantiator": "^1.2",
-                "php": "^7.2 || ~8.0, <8.2",
-                "phpdocumentor/reflection-docblock": "^5.2",
-                "sebastian/comparator": "^3.0 || ^4.0",
-                "sebastian/recursion-context": "^3.0 || ^4.0"
-            },
-            "require-dev": {
-                "phpspec/phpspec": "^6.0 || ^7.0",
-                "phpunit/phpunit": "^8.0 || ^9.0"
-            },
-            "type": "library",
-            "extra": {
-                "branch-alias": {
-                    "dev-master": "1.x-dev"
-                }
-            },
-            "autoload": {
-                "psr-4": {
-                    "Prophecy\\": "src/Prophecy"
-                }
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "MIT"
-            ],
-            "authors": [
-                {
-                    "name": "Konstantin Kudryashov",
-                    "email": "ever.zet@gmail.com",
-                    "homepage": "http://everzet.com"
-                },
-                {
-                    "name": "Marcello Duarte",
-                    "email": "marcello.duarte@gmail.com"
-                }
-            ],
-            "description": "Highly opinionated mocking framework for PHP 5.3+",
-            "homepage": "https://github.com/phpspec/prophecy",
-            "keywords": [
-                "Double",
-                "Dummy",
-                "fake",
-                "mock",
-                "spy",
-                "stub"
-            ],
-            "support": {
-                "issues": "https://github.com/phpspec/prophecy/issues",
-                "source": "https://github.com/phpspec/prophecy/tree/v1.15.0"
-            },
-            "time": "2021-12-08T12:19:24+00:00"
-        },
-        {
             "name": "phpunit/php-code-coverage",
-            "version": "9.2.15",
+            "version": "9.2.16",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/php-code-coverage.git",
-                "reference": "2e9da11878c4202f97915c1cb4bb1ca318a63f5f"
+                "reference": "2593003befdcc10db5e213f9f28814f5aa8ac073"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/php-code-coverage/zipball/2e9da11878c4202f97915c1cb4bb1ca318a63f5f",
-                "reference": "2e9da11878c4202f97915c1cb4bb1ca318a63f5f",
+                "url": "https://api.github.com/repos/sebastianbergmann/php-code-coverage/zipball/2593003befdcc10db5e213f9f28814f5aa8ac073",
+                "reference": "2593003befdcc10db5e213f9f28814f5aa8ac073",
                 "shasum": ""
             },
             "require": {
                 "ext-dom": "*",
                 "ext-libxml": "*",
                 "ext-xmlwriter": "*",
-                "nikic/php-parser": "^4.13.0",
+                "nikic/php-parser": "^4.14",
                 "php": ">=7.3",
                 "phpunit/php-file-iterator": "^3.0.3",
                 "phpunit/php-text-template": "^2.0.2",
@@ -1273,7 +995,7 @@
             ],
             "support": {
                 "issues": "https://github.com/sebastianbergmann/php-code-coverage/issues",
-                "source": "https://github.com/sebastianbergmann/php-code-coverage/tree/9.2.15"
+                "source": "https://github.com/sebastianbergmann/php-code-coverage/tree/9.2.16"
             },
             "funding": [
                 {
@@ -1281,7 +1003,7 @@
                     "type": "github"
                 }
             ],
-            "time": "2022-03-07T09:28:20+00:00"
+            "time": "2022-08-20T05:26:47+00:00"
         },
         {
             "name": "phpunit/php-file-iterator",
@@ -1526,16 +1248,16 @@
         },
         {
             "name": "phpunit/phpunit",
-            "version": "9.5.20",
+            "version": "9.5.23",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/phpunit.git",
-                "reference": "12bc8879fb65aef2138b26fc633cb1e3620cffba"
+                "reference": "888556852e7e9bbeeedb9656afe46118765ade34"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/phpunit/zipball/12bc8879fb65aef2138b26fc633cb1e3620cffba",
-                "reference": "12bc8879fb65aef2138b26fc633cb1e3620cffba",
+                "url": "https://api.github.com/repos/sebastianbergmann/phpunit/zipball/888556852e7e9bbeeedb9656afe46118765ade34",
+                "reference": "888556852e7e9bbeeedb9656afe46118765ade34",
                 "shasum": ""
             },
             "require": {
@@ -1550,7 +1272,6 @@
                 "phar-io/manifest": "^2.0.3",
                 "phar-io/version": "^3.0.2",
                 "php": ">=7.3",
-                "phpspec/prophecy": "^1.12.1",
                 "phpunit/php-code-coverage": "^9.2.13",
                 "phpunit/php-file-iterator": "^3.0.5",
                 "phpunit/php-invoker": "^3.1.1",
@@ -1567,10 +1288,6 @@
                 "sebastian/resource-operations": "^3.0.3",
                 "sebastian/type": "^3.0",
                 "sebastian/version": "^3.0.2"
-            },
-            "require-dev": {
-                "ext-pdo": "*",
-                "phpspec/prophecy-phpunit": "^2.0.1"
             },
             "suggest": {
                 "ext-soap": "*",
@@ -1613,7 +1330,7 @@
             ],
             "support": {
                 "issues": "https://github.com/sebastianbergmann/phpunit/issues",
-                "source": "https://github.com/sebastianbergmann/phpunit/tree/9.5.20"
+                "source": "https://github.com/sebastianbergmann/phpunit/tree/9.5.23"
             },
             "funding": [
                 {
@@ -1625,7 +1342,7 @@
                     "type": "github"
                 }
             ],
-            "time": "2022-04-01T12:37:26+00:00"
+            "time": "2022-08-22T14:01:36+00:00"
         },
         {
             "name": "psr/cache",
@@ -2795,16 +2512,16 @@
         },
         {
             "name": "symfony/console",
-            "version": "v6.0.7",
+            "version": "v6.0.11",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/console.git",
-                "reference": "70dcf7b2ca2ea08ad6ebcc475f104a024fb5632e"
+                "reference": "09b8e50f09bf0e5bbde9b61b19d7f53751114725"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/console/zipball/70dcf7b2ca2ea08ad6ebcc475f104a024fb5632e",
-                "reference": "70dcf7b2ca2ea08ad6ebcc475f104a024fb5632e",
+                "url": "https://api.github.com/repos/symfony/console/zipball/09b8e50f09bf0e5bbde9b61b19d7f53751114725",
+                "reference": "09b8e50f09bf0e5bbde9b61b19d7f53751114725",
                 "shasum": ""
             },
             "require": {
@@ -2870,7 +2587,7 @@
                 "terminal"
             ],
             "support": {
-                "source": "https://github.com/symfony/console/tree/v6.0.7"
+                "source": "https://github.com/symfony/console/tree/v6.0.11"
             },
             "funding": [
                 {
@@ -2886,11 +2603,11 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2022-03-31T17:18:25+00:00"
+            "time": "2022-07-22T14:17:38+00:00"
         },
         {
             "name": "symfony/deprecation-contracts",
-            "version": "v3.0.1",
+            "version": "v3.0.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/deprecation-contracts.git",
@@ -2937,7 +2654,7 @@
             "description": "A generic function and convention to trigger deprecation notices",
             "homepage": "https://symfony.com",
             "support": {
-                "source": "https://github.com/symfony/deprecation-contracts/tree/v3.0.1"
+                "source": "https://github.com/symfony/deprecation-contracts/tree/v3.0.2"
             },
             "funding": [
                 {
@@ -2957,16 +2674,16 @@
         },
         {
             "name": "symfony/event-dispatcher",
-            "version": "v6.0.3",
+            "version": "v6.0.9",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/event-dispatcher.git",
-                "reference": "6472ea2dd415e925b90ca82be64b8bc6157f3934"
+                "reference": "5c85b58422865d42c6eb46f7693339056db098a8"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/event-dispatcher/zipball/6472ea2dd415e925b90ca82be64b8bc6157f3934",
-                "reference": "6472ea2dd415e925b90ca82be64b8bc6157f3934",
+                "url": "https://api.github.com/repos/symfony/event-dispatcher/zipball/5c85b58422865d42c6eb46f7693339056db098a8",
+                "reference": "5c85b58422865d42c6eb46f7693339056db098a8",
                 "shasum": ""
             },
             "require": {
@@ -3020,7 +2737,7 @@
             "description": "Provides tools that allow your application components to communicate with each other by dispatching events and listening to them",
             "homepage": "https://symfony.com",
             "support": {
-                "source": "https://github.com/symfony/event-dispatcher/tree/v6.0.3"
+                "source": "https://github.com/symfony/event-dispatcher/tree/v6.0.9"
             },
             "funding": [
                 {
@@ -3036,11 +2753,11 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2022-01-02T09:55:41+00:00"
+            "time": "2022-05-05T16:45:52+00:00"
         },
         {
             "name": "symfony/event-dispatcher-contracts",
-            "version": "v3.0.1",
+            "version": "v3.0.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/event-dispatcher-contracts.git",
@@ -3099,7 +2816,7 @@
                 "standards"
             ],
             "support": {
-                "source": "https://github.com/symfony/event-dispatcher-contracts/tree/v3.0.1"
+                "source": "https://github.com/symfony/event-dispatcher-contracts/tree/v3.0.2"
             },
             "funding": [
                 {
@@ -3119,16 +2836,16 @@
         },
         {
             "name": "symfony/filesystem",
-            "version": "v6.0.7",
+            "version": "v6.0.11",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/filesystem.git",
-                "reference": "6c9e4c41f2c51dfde3db298594ed9cba55dbf5ff"
+                "reference": "33787a6b6e055245d5710697dfc4a9a2b896c032"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/filesystem/zipball/6c9e4c41f2c51dfde3db298594ed9cba55dbf5ff",
-                "reference": "6c9e4c41f2c51dfde3db298594ed9cba55dbf5ff",
+                "url": "https://api.github.com/repos/symfony/filesystem/zipball/33787a6b6e055245d5710697dfc4a9a2b896c032",
+                "reference": "33787a6b6e055245d5710697dfc4a9a2b896c032",
                 "shasum": ""
             },
             "require": {
@@ -3162,7 +2879,7 @@
             "description": "Provides basic utilities for the filesystem",
             "homepage": "https://symfony.com",
             "support": {
-                "source": "https://github.com/symfony/filesystem/tree/v6.0.7"
+                "source": "https://github.com/symfony/filesystem/tree/v6.0.11"
             },
             "funding": [
                 {
@@ -3178,20 +2895,20 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2022-04-01T12:54:51+00:00"
+            "time": "2022-07-20T14:06:08+00:00"
         },
         {
             "name": "symfony/finder",
-            "version": "v6.0.3",
+            "version": "v6.0.11",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/finder.git",
-                "reference": "8661b74dbabc23223f38c9b99d3f8ade71170430"
+                "reference": "09cb683ba5720385ea6966e5e06be2a34f2568b1"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/finder/zipball/8661b74dbabc23223f38c9b99d3f8ade71170430",
-                "reference": "8661b74dbabc23223f38c9b99d3f8ade71170430",
+                "url": "https://api.github.com/repos/symfony/finder/zipball/09cb683ba5720385ea6966e5e06be2a34f2568b1",
+                "reference": "09cb683ba5720385ea6966e5e06be2a34f2568b1",
                 "shasum": ""
             },
             "require": {
@@ -3223,7 +2940,7 @@
             "description": "Finds files and directories via an intuitive fluent interface",
             "homepage": "https://symfony.com",
             "support": {
-                "source": "https://github.com/symfony/finder/tree/v6.0.3"
+                "source": "https://github.com/symfony/finder/tree/v6.0.11"
             },
             "funding": [
                 {
@@ -3239,7 +2956,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2022-01-26T17:23:29+00:00"
+            "time": "2022-07-29T07:39:48+00:00"
         },
         {
             "name": "symfony/options-resolver",
@@ -3310,16 +3027,16 @@
         },
         {
             "name": "symfony/polyfill-ctype",
-            "version": "v1.25.0",
+            "version": "v1.26.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/polyfill-ctype.git",
-                "reference": "30885182c981ab175d4d034db0f6f469898070ab"
+                "reference": "6fd1b9a79f6e3cf65f9e679b23af304cd9e010d4"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/polyfill-ctype/zipball/30885182c981ab175d4d034db0f6f469898070ab",
-                "reference": "30885182c981ab175d4d034db0f6f469898070ab",
+                "url": "https://api.github.com/repos/symfony/polyfill-ctype/zipball/6fd1b9a79f6e3cf65f9e679b23af304cd9e010d4",
+                "reference": "6fd1b9a79f6e3cf65f9e679b23af304cd9e010d4",
                 "shasum": ""
             },
             "require": {
@@ -3334,7 +3051,7 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-main": "1.23-dev"
+                    "dev-main": "1.26-dev"
                 },
                 "thanks": {
                     "name": "symfony/polyfill",
@@ -3372,7 +3089,7 @@
                 "portable"
             ],
             "support": {
-                "source": "https://github.com/symfony/polyfill-ctype/tree/v1.25.0"
+                "source": "https://github.com/symfony/polyfill-ctype/tree/v1.26.0"
             },
             "funding": [
                 {
@@ -3388,20 +3105,20 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2021-10-20T20:35:02+00:00"
+            "time": "2022-05-24T11:49:31+00:00"
         },
         {
             "name": "symfony/polyfill-intl-grapheme",
-            "version": "v1.25.0",
+            "version": "v1.26.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/polyfill-intl-grapheme.git",
-                "reference": "81b86b50cf841a64252b439e738e97f4a34e2783"
+                "reference": "433d05519ce6990bf3530fba6957499d327395c2"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/polyfill-intl-grapheme/zipball/81b86b50cf841a64252b439e738e97f4a34e2783",
-                "reference": "81b86b50cf841a64252b439e738e97f4a34e2783",
+                "url": "https://api.github.com/repos/symfony/polyfill-intl-grapheme/zipball/433d05519ce6990bf3530fba6957499d327395c2",
+                "reference": "433d05519ce6990bf3530fba6957499d327395c2",
                 "shasum": ""
             },
             "require": {
@@ -3413,7 +3130,7 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-main": "1.23-dev"
+                    "dev-main": "1.26-dev"
                 },
                 "thanks": {
                     "name": "symfony/polyfill",
@@ -3453,7 +3170,7 @@
                 "shim"
             ],
             "support": {
-                "source": "https://github.com/symfony/polyfill-intl-grapheme/tree/v1.25.0"
+                "source": "https://github.com/symfony/polyfill-intl-grapheme/tree/v1.26.0"
             },
             "funding": [
                 {
@@ -3469,20 +3186,20 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2021-11-23T21:10:46+00:00"
+            "time": "2022-05-24T11:49:31+00:00"
         },
         {
             "name": "symfony/polyfill-intl-normalizer",
-            "version": "v1.25.0",
+            "version": "v1.26.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/polyfill-intl-normalizer.git",
-                "reference": "8590a5f561694770bdcd3f9b5c69dde6945028e8"
+                "reference": "219aa369ceff116e673852dce47c3a41794c14bd"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/polyfill-intl-normalizer/zipball/8590a5f561694770bdcd3f9b5c69dde6945028e8",
-                "reference": "8590a5f561694770bdcd3f9b5c69dde6945028e8",
+                "url": "https://api.github.com/repos/symfony/polyfill-intl-normalizer/zipball/219aa369ceff116e673852dce47c3a41794c14bd",
+                "reference": "219aa369ceff116e673852dce47c3a41794c14bd",
                 "shasum": ""
             },
             "require": {
@@ -3494,7 +3211,7 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-main": "1.23-dev"
+                    "dev-main": "1.26-dev"
                 },
                 "thanks": {
                     "name": "symfony/polyfill",
@@ -3537,7 +3254,7 @@
                 "shim"
             ],
             "support": {
-                "source": "https://github.com/symfony/polyfill-intl-normalizer/tree/v1.25.0"
+                "source": "https://github.com/symfony/polyfill-intl-normalizer/tree/v1.26.0"
             },
             "funding": [
                 {
@@ -3553,20 +3270,20 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2021-02-19T12:13:01+00:00"
+            "time": "2022-05-24T11:49:31+00:00"
         },
         {
             "name": "symfony/polyfill-mbstring",
-            "version": "v1.25.0",
+            "version": "v1.26.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/polyfill-mbstring.git",
-                "reference": "0abb51d2f102e00a4eefcf46ba7fec406d245825"
+                "reference": "9344f9cb97f3b19424af1a21a3b0e75b0a7d8d7e"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/polyfill-mbstring/zipball/0abb51d2f102e00a4eefcf46ba7fec406d245825",
-                "reference": "0abb51d2f102e00a4eefcf46ba7fec406d245825",
+                "url": "https://api.github.com/repos/symfony/polyfill-mbstring/zipball/9344f9cb97f3b19424af1a21a3b0e75b0a7d8d7e",
+                "reference": "9344f9cb97f3b19424af1a21a3b0e75b0a7d8d7e",
                 "shasum": ""
             },
             "require": {
@@ -3581,7 +3298,7 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-main": "1.23-dev"
+                    "dev-main": "1.26-dev"
                 },
                 "thanks": {
                     "name": "symfony/polyfill",
@@ -3620,7 +3337,7 @@
                 "shim"
             ],
             "support": {
-                "source": "https://github.com/symfony/polyfill-mbstring/tree/v1.25.0"
+                "source": "https://github.com/symfony/polyfill-mbstring/tree/v1.26.0"
             },
             "funding": [
                 {
@@ -3636,20 +3353,20 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2021-11-30T18:21:41+00:00"
+            "time": "2022-05-24T11:49:31+00:00"
         },
         {
             "name": "symfony/polyfill-php80",
-            "version": "v1.25.0",
+            "version": "v1.26.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/polyfill-php80.git",
-                "reference": "4407588e0d3f1f52efb65fbe92babe41f37fe50c"
+                "reference": "cfa0ae98841b9e461207c13ab093d76b0fa7bace"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/polyfill-php80/zipball/4407588e0d3f1f52efb65fbe92babe41f37fe50c",
-                "reference": "4407588e0d3f1f52efb65fbe92babe41f37fe50c",
+                "url": "https://api.github.com/repos/symfony/polyfill-php80/zipball/cfa0ae98841b9e461207c13ab093d76b0fa7bace",
+                "reference": "cfa0ae98841b9e461207c13ab093d76b0fa7bace",
                 "shasum": ""
             },
             "require": {
@@ -3658,7 +3375,7 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-main": "1.23-dev"
+                    "dev-main": "1.26-dev"
                 },
                 "thanks": {
                     "name": "symfony/polyfill",
@@ -3703,7 +3420,7 @@
                 "shim"
             ],
             "support": {
-                "source": "https://github.com/symfony/polyfill-php80/tree/v1.25.0"
+                "source": "https://github.com/symfony/polyfill-php80/tree/v1.26.0"
             },
             "funding": [
                 {
@@ -3719,20 +3436,20 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2022-03-04T08:16:47+00:00"
+            "time": "2022-05-10T07:21:04+00:00"
         },
         {
             "name": "symfony/polyfill-php81",
-            "version": "v1.25.0",
+            "version": "v1.26.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/polyfill-php81.git",
-                "reference": "5de4ba2d41b15f9bd0e19b2ab9674135813ec98f"
+                "reference": "13f6d1271c663dc5ae9fb843a8f16521db7687a1"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/polyfill-php81/zipball/5de4ba2d41b15f9bd0e19b2ab9674135813ec98f",
-                "reference": "5de4ba2d41b15f9bd0e19b2ab9674135813ec98f",
+                "url": "https://api.github.com/repos/symfony/polyfill-php81/zipball/13f6d1271c663dc5ae9fb843a8f16521db7687a1",
+                "reference": "13f6d1271c663dc5ae9fb843a8f16521db7687a1",
                 "shasum": ""
             },
             "require": {
@@ -3741,7 +3458,7 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-main": "1.23-dev"
+                    "dev-main": "1.26-dev"
                 },
                 "thanks": {
                     "name": "symfony/polyfill",
@@ -3782,7 +3499,7 @@
                 "shim"
             ],
             "support": {
-                "source": "https://github.com/symfony/polyfill-php81/tree/v1.25.0"
+                "source": "https://github.com/symfony/polyfill-php81/tree/v1.26.0"
             },
             "funding": [
                 {
@@ -3798,20 +3515,20 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2021-09-13T13:58:11+00:00"
+            "time": "2022-05-24T11:49:31+00:00"
         },
         {
             "name": "symfony/process",
-            "version": "v6.0.7",
+            "version": "v6.0.11",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/process.git",
-                "reference": "e13f6757e267d687e20ec5b26ccfcbbe511cd8f4"
+                "reference": "44270a08ccb664143dede554ff1c00aaa2247a43"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/process/zipball/e13f6757e267d687e20ec5b26ccfcbbe511cd8f4",
-                "reference": "e13f6757e267d687e20ec5b26ccfcbbe511cd8f4",
+                "url": "https://api.github.com/repos/symfony/process/zipball/44270a08ccb664143dede554ff1c00aaa2247a43",
+                "reference": "44270a08ccb664143dede554ff1c00aaa2247a43",
                 "shasum": ""
             },
             "require": {
@@ -3843,7 +3560,7 @@
             "description": "Executes commands in sub-processes",
             "homepage": "https://symfony.com",
             "support": {
-                "source": "https://github.com/symfony/process/tree/v6.0.7"
+                "source": "https://github.com/symfony/process/tree/v6.0.11"
             },
             "funding": [
                 {
@@ -3859,20 +3576,20 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2022-03-18T16:21:55+00:00"
+            "time": "2022-06-27T17:10:44+00:00"
         },
         {
             "name": "symfony/service-contracts",
-            "version": "v3.0.1",
+            "version": "v3.0.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/service-contracts.git",
-                "reference": "e517458f278c2131ca9f262f8fbaf01410f2c65c"
+                "reference": "d78d39c1599bd1188b8e26bb341da52c3c6d8a66"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/service-contracts/zipball/e517458f278c2131ca9f262f8fbaf01410f2c65c",
-                "reference": "e517458f278c2131ca9f262f8fbaf01410f2c65c",
+                "url": "https://api.github.com/repos/symfony/service-contracts/zipball/d78d39c1599bd1188b8e26bb341da52c3c6d8a66",
+                "reference": "d78d39c1599bd1188b8e26bb341da52c3c6d8a66",
                 "shasum": ""
             },
             "require": {
@@ -3925,7 +3642,7 @@
                 "standards"
             ],
             "support": {
-                "source": "https://github.com/symfony/service-contracts/tree/v3.0.1"
+                "source": "https://github.com/symfony/service-contracts/tree/v3.0.2"
             },
             "funding": [
                 {
@@ -3941,7 +3658,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2022-03-13T20:10:05+00:00"
+            "time": "2022-05-30T19:17:58+00:00"
         },
         {
             "name": "symfony/stopwatch",
@@ -4007,16 +3724,16 @@
         },
         {
             "name": "symfony/string",
-            "version": "v6.0.3",
+            "version": "v6.0.11",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/string.git",
-                "reference": "522144f0c4c004c80d56fa47e40e17028e2eefc2"
+                "reference": "042b6bf0f6ccca6d456a0572eb788cfb8b1ff809"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/string/zipball/522144f0c4c004c80d56fa47e40e17028e2eefc2",
-                "reference": "522144f0c4c004c80d56fa47e40e17028e2eefc2",
+                "url": "https://api.github.com/repos/symfony/string/zipball/042b6bf0f6ccca6d456a0572eb788cfb8b1ff809",
+                "reference": "042b6bf0f6ccca6d456a0572eb788cfb8b1ff809",
                 "shasum": ""
             },
             "require": {
@@ -4072,7 +3789,7 @@
                 "utf8"
             ],
             "support": {
-                "source": "https://github.com/symfony/string/tree/v6.0.3"
+                "source": "https://github.com/symfony/string/tree/v6.0.11"
             },
             "funding": [
                 {
@@ -4088,7 +3805,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2022-01-02T09:55:41+00:00"
+            "time": "2022-07-27T15:50:26+00:00"
         },
         {
             "name": "theseer/tokenizer",
@@ -4139,74 +3856,18 @@
                 }
             ],
             "time": "2021-07-28T10:34:58+00:00"
-        },
-        {
-            "name": "webmozart/assert",
-            "version": "1.10.0",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/webmozarts/assert.git",
-                "reference": "6964c76c7804814a842473e0c8fd15bab0f18e25"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/webmozarts/assert/zipball/6964c76c7804814a842473e0c8fd15bab0f18e25",
-                "reference": "6964c76c7804814a842473e0c8fd15bab0f18e25",
-                "shasum": ""
-            },
-            "require": {
-                "php": "^7.2 || ^8.0",
-                "symfony/polyfill-ctype": "^1.8"
-            },
-            "conflict": {
-                "phpstan/phpstan": "<0.12.20",
-                "vimeo/psalm": "<4.6.1 || 4.6.2"
-            },
-            "require-dev": {
-                "phpunit/phpunit": "^8.5.13"
-            },
-            "type": "library",
-            "extra": {
-                "branch-alias": {
-                    "dev-master": "1.10-dev"
-                }
-            },
-            "autoload": {
-                "psr-4": {
-                    "Webmozart\\Assert\\": "src/"
-                }
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "MIT"
-            ],
-            "authors": [
-                {
-                    "name": "Bernhard Schussek",
-                    "email": "bschussek@gmail.com"
-                }
-            ],
-            "description": "Assertions to validate method input/output with nice error messages.",
-            "keywords": [
-                "assert",
-                "check",
-                "validate"
-            ],
-            "support": {
-                "issues": "https://github.com/webmozarts/assert/issues",
-                "source": "https://github.com/webmozarts/assert/tree/1.10.0"
-            },
-            "time": "2021-03-09T10:59:23+00:00"
         }
     ],
     "aliases": [],
     "minimum-stability": "stable",
-    "stability-flags": [],
+    "stability-flags": {
+        "dave-liddament/php-language-extensions": 20
+    },
     "prefer-stable": false,
     "prefer-lowest": false,
     "platform": {
         "php": "^8"
     },
     "platform-dev": [],
-    "plugin-api-version": "2.2.0"
+    "plugin-api-version": "2.3.0"
 }

--- a/extension.neon
+++ b/extension.neon
@@ -27,6 +27,22 @@ services:
         - phpstan.rules.rule
 
     -
+        class: DaveLiddament\PhpstanPhpLanguageExtensions\Rules\CallableFromMethodCallRule
+        tags:
+        - phpstan.rules.rule
+
+    -
+        class: DaveLiddament\PhpstanPhpLanguageExtensions\Rules\CallableFromNewCallRule
+        tags:
+        - phpstan.rules.rule
+
+    -
+        class: DaveLiddament\PhpstanPhpLanguageExtensions\Rules\CallableFromStaticCallRule
+        tags:
+        - phpstan.rules.rule
+
+
+    -
         class: DaveLiddament\PhpstanPhpLanguageExtensions\Rules\PackageMethodCallRule
         tags:
         - phpstan.rules.rule

--- a/src/Helpers/AttributeValueReader.php
+++ b/src/Helpers/AttributeValueReader.php
@@ -10,15 +10,15 @@ class AttributeValueReader
      * @param \ReflectionClass<object> $reflectionClass
      * @param class-string $attributeClassName
      *
-     * @return array<int, string>
+     * @return array<int, string>|null
      */
     public static function getAttributeValuesForMethod(
         \ReflectionClass $reflectionClass,
         string $methodName,
         string $attributeClassName,
-    ): array {
+    ): ?array {
         if (!$reflectionClass->hasMethod($methodName)) {
-            return [];
+            return null;
         }
         $reflectionMethod = $reflectionClass->getMethod($methodName);
 
@@ -26,23 +26,23 @@ class AttributeValueReader
             return $attribute->getArguments();
         }
 
-        return [];
+        return null;
     }
 
     /**
      * @param \ReflectionClass<object> $reflectionClass
      * @param class-string $attributeClassName
      *
-     * @return array<int, string>
+     * @return array<int|string, string>|null
      */
     public static function getAttributeValuesForClass(
         \ReflectionClass $reflectionClass,
         string $attributeClassName,
-    ): array {
+    ): ?array {
         foreach ($reflectionClass->getAttributes($attributeClassName) as $attribute) {
             return $attribute->getArguments();
         }
 
-        return [];
+        return null;
     }
 }

--- a/src/Helpers/SubNamespaceChecker.php
+++ b/src/Helpers/SubNamespaceChecker.php
@@ -2,20 +2,17 @@
 
 declare(strict_types=1);
 
-
 namespace DaveLiddament\PhpstanPhpLanguageExtensions\Helpers;
-
 
 class SubNamespaceChecker
 {
-
     public static function isSubNamespace(string $namespace, string $namespaceToCheckAgainst): bool
     {
         if ($namespace === $namespaceToCheckAgainst) {
             return true;
         }
 
-        if (str_starts_with(needle: $namespaceToCheckAgainst . '\\', haystack: $namespace )) {
+        if (str_starts_with(needle: $namespaceToCheckAgainst.'\\', haystack: $namespace)) {
             return true;
         }
 

--- a/src/Helpers/SubNamespaceChecker.php
+++ b/src/Helpers/SubNamespaceChecker.php
@@ -1,0 +1,24 @@
+<?php
+
+declare(strict_types=1);
+
+
+namespace DaveLiddament\PhpstanPhpLanguageExtensions\Helpers;
+
+
+class SubNamespaceChecker
+{
+
+    public static function isSubNamespace(string $namespace, string $namespaceToCheckAgainst): bool
+    {
+        if ($namespace === $namespaceToCheckAgainst) {
+            return true;
+        }
+
+        if (str_starts_with(needle: $namespaceToCheckAgainst . '\\', haystack: $namespace )) {
+            return true;
+        }
+
+        return false;
+    }
+}

--- a/src/Rules/AbstractCallableFromRule.php
+++ b/src/Rules/AbstractCallableFromRule.php
@@ -1,0 +1,96 @@
+<?php
+
+declare(strict_types=1);
+
+namespace DaveLiddament\PhpstanPhpLanguageExtensions\Rules;
+
+use DaveLiddament\PhpLanguageExtensions\CallableFrom;
+use DaveLiddament\PhpstanPhpLanguageExtensions\Config\TestConfig;
+use DaveLiddament\PhpstanPhpLanguageExtensions\Helpers\AttributeValueReader;
+use DaveLiddament\PhpstanPhpLanguageExtensions\Helpers\Cache;
+use DaveLiddament\PhpstanPhpLanguageExtensions\Helpers\TestClassChecker;
+use PHPStan\Analyser\Scope;
+use PHPStan\Reflection\ReflectionProvider;
+use PHPStan\Rules\Rule;
+use PHPStan\Rules\RuleError;
+use PHPStan\Rules\RuleErrorBuilder;
+
+/**
+ * @template TNodeType of \PhpParser\Node
+ * @implements Rule<TNodeType>
+ */
+abstract class AbstractCallableFromRule implements Rule
+{
+    /**
+     * @var Cache<array<int,string>>
+     */
+    private Cache $cache;
+    private TestClassChecker $testClassChecker;
+
+    final public function __construct(
+        private ReflectionProvider $reflectionProvider,
+        private TestConfig $testConfig,
+    ) {
+        $this->cache = new Cache();
+        $this->testClassChecker = new TestClassChecker($this->testConfig);
+    }
+
+    protected function getErrorOrNull(
+        Scope $scope,
+        string $class,
+        string $methodName,
+    ): ?RuleError {
+        $callingClass = $scope->getClassReflection()?->getName();
+        $classReflection = $this->reflectionProvider->getClass($class);
+        $className = $classReflection->getName();
+        $fullMethodName = "{$className}::{$methodName}";
+
+        if ($this->cache->hasEntry($fullMethodName)) {
+            $allowedCallingClassesFromMethod = $this->cache->getEntry($fullMethodName);
+        } else {
+            $allowedCallingClassesFromMethod = AttributeValueReader::getAttributeValuesForMethod(
+                $classReflection->getNativeReflection(),
+                $methodName,
+                CallableFrom::class
+            );
+            $this->cache->addEntry($fullMethodName, $allowedCallingClassesFromMethod);
+        }
+
+        if ($this->cache->hasEntry($className)) {
+            $allowedCallingClassesFromClass = $this->cache->getEntry($className);
+        } else {
+            $allowedCallingClassesFromClass = AttributeValueReader::getAttributeValuesForClass(
+                $classReflection->getNativeReflection(),
+                CallableFrom::class
+            );
+            $this->cache->addEntry($className, $allowedCallingClassesFromClass);
+        }
+
+        $allowedCallingClasses = array_merge($allowedCallingClassesFromClass, $allowedCallingClassesFromMethod);
+
+        if ([] === $allowedCallingClasses) {
+            return null;
+        }
+
+        if ($callingClass === $className) {
+            return null;
+        }
+
+        if (in_array($callingClass, $allowedCallingClasses, true)) {
+            return null;
+        }
+
+        if ($this->testClassChecker->isTestClass($scope->getNamespace(), $scope->getClassReflection()?->getName())) {
+            return null;
+        }
+
+        $message = sprintf(
+            '%s cannot be called from %s, it can only be called from classes: %s',
+            $fullMethodName,
+            $callingClass ?? '<no class>',
+            implode('|', $allowedCallingClasses)
+        );
+
+        return RuleErrorBuilder::message($message)->build();
+    }
+}

--- a/src/Rules/AbstractCallableFromRule.php
+++ b/src/Rules/AbstractCallableFromRule.php
@@ -22,7 +22,7 @@ use PHPStan\Rules\RuleErrorBuilder;
 abstract class AbstractCallableFromRule implements Rule
 {
     /**
-     * @var Cache<array<int,string>>
+     * @var Cache<array<array-key,string>|null>
      */
     private Cache $cache;
     private TestClassChecker $testClassChecker;
@@ -66,12 +66,18 @@ abstract class AbstractCallableFromRule implements Rule
             $this->cache->addEntry($className, $allowedCallingClassesFromClass);
         }
 
-        $allowedCallingClasses = array_merge($allowedCallingClassesFromClass, $allowedCallingClassesFromMethod);
-
-        if ([] === $allowedCallingClasses) {
+        // If method and class does not have a CallableFrom attribute then finish processing.
+        if ((null === $allowedCallingClassesFromClass) && (null === $allowedCallingClassesFromMethod)) {
             return null;
         }
 
+        $allowedCallingClasses =
+            array_merge(
+                $allowedCallingClassesFromClass ?? [],
+                $allowedCallingClassesFromMethod ?? [],
+            );
+
+        // Allow calls from the same class
         if ($callingClass === $className) {
             return null;
         }

--- a/src/Rules/AbstractFriendRule.php
+++ b/src/Rules/AbstractFriendRule.php
@@ -22,7 +22,7 @@ use PHPStan\Rules\RuleErrorBuilder;
 abstract class AbstractFriendRule implements Rule
 {
     /**
-     * @var Cache<array<int,string>>
+     * @var Cache<array<array-key,string>|null>
      */
     private Cache $cache;
     private TestClassChecker $testClassChecker;
@@ -65,12 +65,16 @@ abstract class AbstractFriendRule implements Rule
             );
             $this->cache->addEntry($className, $allowedCallingClassesFromClass);
         }
-
-        $allowedCallingClasses = array_merge($allowedCallingClassesFromClass, $allowedCallingClassesFromMethod);
-
-        if ([] === $allowedCallingClasses) {
+        // If method and class does not have a CallableFrom attribute then finish processing.
+        if ((null === $allowedCallingClassesFromClass) && (null === $allowedCallingClassesFromMethod)) {
             return null;
         }
+
+        $allowedCallingClasses =
+            array_merge(
+                $allowedCallingClassesFromClass ?? [],
+                $allowedCallingClassesFromMethod ?? [],
+            );
 
         if ($callingClass === $className) {
             return null;

--- a/src/Rules/AbstractNamespaceVisibilityRule.php
+++ b/src/Rules/AbstractNamespaceVisibilityRule.php
@@ -1,0 +1,127 @@
+<?php
+
+declare(strict_types=1);
+
+namespace DaveLiddament\PhpstanPhpLanguageExtensions\Rules;
+
+use DaveLiddament\PhpLanguageExtensions\NamespaceVisibility;
+use DaveLiddament\PhpstanPhpLanguageExtensions\Config\TestConfig;
+use DaveLiddament\PhpstanPhpLanguageExtensions\Helpers\Cache;
+use DaveLiddament\PhpstanPhpLanguageExtensions\Helpers\SubNamespaceChecker;
+use DaveLiddament\PhpstanPhpLanguageExtensions\Helpers\TestClassChecker;
+use PHPStan\Analyser\Scope;
+use PHPStan\Reflection\ReflectionProvider;
+use PHPStan\Rules\Rule;
+use PHPStan\Rules\RuleError;
+use PHPStan\Rules\RuleErrorBuilder;
+
+/**
+ * @template TNodeType of \PhpParser\Node
+ * @implements Rule<TNodeType>
+ */
+abstract class AbstractNamespaceVisibilityRule implements Rule
+{
+    /**
+     * @var Cache<NamespaceVisibilitySetting>
+     */
+    private Cache $cache;
+    private TestClassChecker $testClassChecker;
+
+    final public function __construct(
+        private ReflectionProvider $reflectionProvider,
+        TestConfig $testConfig,
+    ) {
+        $this->cache = new Cache();
+        $this->testClassChecker = new TestClassChecker($testConfig);
+    }
+
+    protected function getErrorOrNull(
+        Scope $scope,
+        string $class,
+        string $methodName,
+    ): ?RuleError {
+        $classReflection = $this->reflectionProvider->getClass($class);
+        $className = $classReflection->getName();
+        $nativeReflection = $classReflection->getNativeReflection();
+
+        $fullMethodName = "{$className}::{$methodName}";
+
+        // Check if method has NamespaceVisibility Attribute
+        if ($this->cache->hasEntry($fullMethodName)) {
+            $methodNamespaceVisibilitySetting = $this->cache->getEntry($fullMethodName);
+        } else {
+            if ($nativeReflection->hasMethod($methodName)) {
+                $methodReflection = $nativeReflection->getMethod($methodName);
+                if (count($methodReflection->getAttributes(NamespaceVisibility::class)) > 0) {
+                    $methodNamespaceVisibilitySetting = NamespaceVisibilitySetting::namespaceVisibility(
+                        $nativeReflection->getNamespaceName(),
+                        false
+                    );
+                } else {
+                    $methodNamespaceVisibilitySetting = NamespaceVisibilitySetting::noNamespaceVisibilityAttribute();
+                }
+            } else {
+                $methodNamespaceVisibilitySetting = NamespaceVisibilitySetting::noNamespaceVisibilityAttribute();
+            }
+            $this->cache->addEntry($fullMethodName, $methodNamespaceVisibilitySetting);
+        }
+
+
+        if ($methodNamespaceVisibilitySetting->hasNamespaceAttribute()) {
+            $namespaceVisibilitySetting = $methodNamespaceVisibilitySetting;
+        } else {
+
+            if ($this->cache->hasEntry($className)) {
+                $classNamespaceVisibilitySetting = $this->cache->getEntry($className);
+            } else {
+                if (count($nativeReflection->getAttributes(NamespaceVisibility::class)) > 0) {
+                    $classNamespaceVisibilitySetting = NamespaceVisibilitySetting::namespaceVisibility(
+                        $nativeReflection->getNamespaceName(),
+                        false,
+                    );
+                } else {
+                    $classNamespaceVisibilitySetting = NamespaceVisibilitySetting::noNamespaceVisibilityAttribute();
+                }
+                $this->cache->addEntry($className, $classNamespaceVisibilitySetting);
+            }
+
+            $namespaceVisibilitySetting = $classNamespaceVisibilitySetting;
+        }
+
+
+        if (!$namespaceVisibilitySetting->hasNamespaceAttribute()) {
+            return null;
+        }
+
+        // Check namespaces match
+        if ($scope->getNamespace() === $namespaceVisibilitySetting->getNamespace()) {
+            return null;
+        }
+
+        // Check if sub namespace (if allowed)
+        $excludeSubNamespaces = $namespaceVisibilitySetting->isExcludeSubNamespaces();
+        if (!$excludeSubNamespaces) {
+            if (SubNamespaceChecker::isSubNamespace(
+                namespace: $scope->getNamespace(),
+                namespaceToCheckAgainst: $namespaceVisibilitySetting->getNamespace(),
+            )) {
+                return null;
+            }
+        }
+
+        if ($this->testClassChecker->isTestClass($scope->getNamespace(), $scope->getClassReflection()?->getName())) {
+            return null;
+        }
+        
+        $callableFromNamespace = $namespaceVisibilitySetting->getNamespace() ?? '<none>';
+        $subNamespaces =  ($excludeSubNamespaces === false) ? " and sub namespaces of {$callableFromNamespace}" : '';
+        $message = sprintf(
+            '%s has Namespace Visibility, it can only be called from namespace %s%s',
+            $fullMethodName,
+            $callableFromNamespace,
+            $subNamespaces,
+        );
+
+        return RuleErrorBuilder::message($message)->build();
+    }
+}

--- a/src/Rules/CallableFromMethodCallRule.php
+++ b/src/Rules/CallableFromMethodCallRule.php
@@ -1,0 +1,37 @@
+<?php
+
+declare(strict_types=1);
+
+namespace DaveLiddament\PhpstanPhpLanguageExtensions\Rules;
+
+use PhpParser\Node;
+use PhpParser\Node\Expr\MethodCall;
+use PHPStan\Analyser\Scope;
+
+/** @extends  AbstractCallableFromRule<MethodCall> */
+class CallableFromMethodCallRule extends AbstractCallableFromRule
+{
+    public function getNodeType(): string
+    {
+        return MethodCall::class;
+    }
+
+    public function processNode(Node $node, Scope $scope): array
+    {
+        if (!$node->name instanceof Node\Identifier) {
+            return [];
+        }
+
+        $methodName = $node->name->name;
+        $type = $scope->getType($node->var);
+
+        foreach ($type->getReferencedClasses() as $class) {
+            $error = $this->getErrorOrNull($scope, $class, $methodName);
+            if (null !== $error) {
+                return [$error];
+            }
+        }
+
+        return [];
+    }
+}

--- a/src/Rules/CallableFromNewCallRule.php
+++ b/src/Rules/CallableFromNewCallRule.php
@@ -1,0 +1,30 @@
+<?php
+
+declare(strict_types=1);
+
+namespace DaveLiddament\PhpstanPhpLanguageExtensions\Rules;
+
+use PhpParser\Node;
+use PhpParser\Node\Expr\New_;
+use PHPStan\Analyser\Scope;
+
+/** @extends AbstractCallableFromRule<New_> */
+class CallableFromNewCallRule extends AbstractCallableFromRule
+{
+    public function getNodeType(): string
+    {
+        return New_::class;
+    }
+
+    public function processNode(Node $node, Scope $scope): array
+    {
+        if (!$node->class instanceof Node\Name) {
+            return [];
+        }
+
+        $className = $scope->resolveName($node->class);
+        $error = $this->getErrorOrNull($scope, $className, '__construct');
+
+        return (null === $error) ? [] : [$error];
+    }
+}

--- a/src/Rules/CallableFromStaticCallRule.php
+++ b/src/Rules/CallableFromStaticCallRule.php
@@ -1,0 +1,35 @@
+<?php
+
+declare(strict_types=1);
+
+namespace DaveLiddament\PhpstanPhpLanguageExtensions\Rules;
+
+use PhpParser\Node;
+use PhpParser\Node\Expr\StaticCall;
+use PHPStan\Analyser\Scope;
+
+/** @extends AbstractCallableFromRule<StaticCall> */
+class CallableFromStaticCallRule extends AbstractCallableFromRule
+{
+    public function getNodeType(): string
+    {
+        return StaticCall::class;
+    }
+
+    public function processNode(Node $node, Scope $scope): array
+    {
+        if (!$node->name instanceof Node\Identifier) {
+            return [];
+        }
+        $methodName = $node->name->name;
+
+        if (!$node->class instanceof Node\Name) {
+            return [];
+        }
+        $className = $scope->resolveName($node->class);
+
+        $error = $this->getErrorOrNull($scope, $className, $methodName);
+
+        return (null === $error) ? [] : [$error];
+    }
+}

--- a/src/Rules/NamespaceVisibilityMethodCallRule.php
+++ b/src/Rules/NamespaceVisibilityMethodCallRule.php
@@ -1,0 +1,37 @@
+<?php
+
+declare(strict_types=1);
+
+namespace DaveLiddament\PhpstanPhpLanguageExtensions\Rules;
+
+use PhpParser\Node;
+use PhpParser\Node\Expr\MethodCall;
+use PHPStan\Analyser\Scope;
+
+/** @extends AbstractNamespaceVisibilityRule<MethodCall> */
+class NamespaceVisibilityMethodCallRule extends AbstractNamespaceVisibilityRule
+{
+    public function getNodeType(): string
+    {
+        return MethodCall::class;
+    }
+
+    public function processNode(Node $node, Scope $scope): array
+    {
+        if (!$node->name instanceof Node\Identifier) {
+            return [];
+        }
+
+        $methodName = $node->name->name;
+        $type = $scope->getType($node->var);
+
+        foreach ($type->getReferencedClasses() as $class) {
+            $error = $this->getErrorOrNull($scope, $class, $methodName);
+            if (null !== $error) {
+                return [$error];
+            }
+        }
+
+        return [];
+    }
+}

--- a/src/Rules/NamespaceVisibilityNewCallRule.php
+++ b/src/Rules/NamespaceVisibilityNewCallRule.php
@@ -1,0 +1,30 @@
+<?php
+
+declare(strict_types=1);
+
+namespace DaveLiddament\PhpstanPhpLanguageExtensions\Rules;
+
+use PhpParser\Node;
+use PhpParser\Node\Expr\New_;
+use PHPStan\Analyser\Scope;
+
+/** @extends  AbstractNamespaceVisibilityRule<New_> */
+class NamespaceVisibilityNewCallRule extends AbstractNamespaceVisibilityRule
+{
+    public function getNodeType(): string
+    {
+        return New_::class;
+    }
+
+    public function processNode(Node $node, Scope $scope): array
+    {
+        if (!$node->class instanceof Node\Name) {
+            return [];
+        }
+
+        $className = $scope->resolveName($node->class);
+        $error = $this->getErrorOrNull($scope, $className, '__construct');
+
+        return (null === $error) ? [] : [$error];
+    }
+}

--- a/src/Rules/NamespaceVisibilitySetting.php
+++ b/src/Rules/NamespaceVisibilitySetting.php
@@ -2,21 +2,18 @@
 
 declare(strict_types=1);
 
-
 namespace DaveLiddament\PhpstanPhpLanguageExtensions\Rules;
-
 
 use LogicException;
 
 class NamespaceVisibilitySetting
 {
-
     public static function noNamespaceVisibilityAttribute(): self
     {
         return new self(false, null, null);
     }
 
-    public static function namespaceVisibility(?string $namespace, bool $excludeSubNamespaces): self
+    public static function namespaceVisibility(string $namespace, bool $excludeSubNamespaces): self
     {
         return new self(true, $namespace, $excludeSubNamespaces);
     }
@@ -28,21 +25,24 @@ class NamespaceVisibilitySetting
     ) {
     }
 
-
     public function hasNamespaceAttribute(): bool
     {
         return $this->hasNamespace;
     }
 
-    public function getNamespace(): ?string
+    public function getNamespace(): string
     {
+        if (null === $this->namespace) {
+            throw new LogicException('Only call getNamespace if hasNamespaceAttribute returns true');
+        }
+
         return $this->namespace;
     }
 
     public function isExcludeSubNamespaces(): bool
     {
-        if ($this->excludeSubNamespace === null) {
-            throw new LogicException("Only call isExcludeSubNamespace if hasNamespaceAttribute returns true");
+        if (null === $this->excludeSubNamespace) {
+            throw new LogicException('Only call isExcludeSubNamespace if hasNamespaceAttribute returns true');
         }
 
         return $this->excludeSubNamespace;

--- a/src/Rules/NamespaceVisibilitySetting.php
+++ b/src/Rules/NamespaceVisibilitySetting.php
@@ -1,0 +1,50 @@
+<?php
+
+declare(strict_types=1);
+
+
+namespace DaveLiddament\PhpstanPhpLanguageExtensions\Rules;
+
+
+use LogicException;
+
+class NamespaceVisibilitySetting
+{
+
+    public static function noNamespaceVisibilityAttribute(): self
+    {
+        return new self(false, null, null);
+    }
+
+    public static function namespaceVisibility(?string $namespace, bool $excludeSubNamespaces): self
+    {
+        return new self(true, $namespace, $excludeSubNamespaces);
+    }
+
+    private function __construct(
+        private bool $hasNamespace,
+        private ?string $namespace,
+        private ?bool $excludeSubNamespace
+    ) {
+    }
+
+
+    public function hasNamespaceAttribute(): bool
+    {
+        return $this->hasNamespace;
+    }
+
+    public function getNamespace(): ?string
+    {
+        return $this->namespace;
+    }
+
+    public function isExcludeSubNamespaces(): bool
+    {
+        if ($this->excludeSubNamespace === null) {
+            throw new LogicException("Only call isExcludeSubNamespace if hasNamespaceAttribute returns true");
+        }
+
+        return $this->excludeSubNamespace;
+    }
+}

--- a/src/Rules/NamespaceVisibilitySettingsParser.php
+++ b/src/Rules/NamespaceVisibilitySettingsParser.php
@@ -1,0 +1,51 @@
+<?php
+
+namespace DaveLiddament\PhpstanPhpLanguageExtensions\Rules;
+
+use DaveLiddament\PhpLanguageExtensions\NamespaceVisibility;
+use DaveLiddament\PhpstanPhpLanguageExtensions\Helpers\AttributeValueReader;
+
+class NamespaceVisibilitySettingsParser
+{
+    /** @param \ReflectionClass<object> $reflectionClass */
+    public static function getValuesFromClass(
+        \ReflectionClass $reflectionClass
+    ): NamespaceVisibilitySetting {
+        $values = AttributeValueReader::getAttributeValuesForClass(
+            $reflectionClass,
+            NamespaceVisibility::class,
+        );
+
+        return self::parseValues($values, $reflectionClass->getNamespaceName());
+    }
+
+    /** @param \ReflectionClass<object> $reflectionClass */
+    public static function getValuesFromMethod(
+        \ReflectionClass $reflectionClass,
+        string $method,
+    ): NamespaceVisibilitySetting {
+        $values = AttributeValueReader::getAttributeValuesForMethod(
+            $reflectionClass,
+            $method,
+            NamespaceVisibility::class,
+        );
+
+        return self::parseValues($values, $reflectionClass->getNamespaceName());
+    }
+
+    /** @param array<array-key, mixed>|null $values */
+    private static function parseValues(?array $values, string $attributesNamespace): NamespaceVisibilitySetting
+    {
+        if (null === $values) {
+            return NamespaceVisibilitySetting::noNamespaceVisibilityAttribute();
+        }
+
+        $namespace = $values['namespace'] ?? $values[0] ?? $attributesNamespace;
+        \assert(is_string($namespace));
+
+        $excludeSubNamespaces = $values['excludeSubNamespaces'] ?? $values[1] ?? false;
+        \assert(is_bool($excludeSubNamespaces));
+
+        return NamespaceVisibilitySetting::namespaceVisibility($namespace, $excludeSubNamespaces);
+    }
+}

--- a/src/Rules/NamespaceVisibilityStaticCallRule.php
+++ b/src/Rules/NamespaceVisibilityStaticCallRule.php
@@ -1,0 +1,36 @@
+<?php
+
+declare(strict_types=1);
+
+namespace DaveLiddament\PhpstanPhpLanguageExtensions\Rules;
+
+use PhpParser\Node;
+use PhpParser\Node\Expr\StaticCall;
+use PHPStan\Analyser\Scope;
+
+/** @extends  AbstractNamespaceVisibilityRule<StaticCall> */
+class NamespaceVisibilityStaticCallRule extends AbstractNamespaceVisibilityRule
+{
+    public function getNodeType(): string
+    {
+        return StaticCall::class;
+    }
+
+    public function processNode(Node $node, Scope $scope): array
+    {
+        if (!$node->name instanceof Node\Identifier) {
+            return [];
+        }
+
+        $methodName = $node->name->name;
+
+        if (!$node->class instanceof Node\Name) {
+            return [];
+        }
+        $className = $scope->resolveName($node->class);
+
+        $error = $this->getErrorOrNull($scope, $className, $methodName);
+
+        return (null === $error) ? [] : [$error];
+    }
+}

--- a/tests/Rules/AbstractCallableFromRuleTest.php
+++ b/tests/Rules/AbstractCallableFromRuleTest.php
@@ -1,0 +1,34 @@
+<?php
+
+declare(strict_types=1);
+
+namespace DaveLiddament\PhpstanPhpLanguageExtensions\Tests\Rules;
+
+use PHPStan\Rules\Rule;
+use PHPStan\Testing\RuleTestCase;
+
+/**
+ * @template TRule of Rule
+ * @extends RuleTestCase<TRule>
+ */
+abstract class AbstractCallableFromRuleTest extends RuleTestCase
+{
+    /** @param array<int,array{int,string,string,string}> $errors */
+    final protected function assertErrorsReported(string $file, array $errors): void
+    {
+        $expectedIssues = [];
+        foreach ($errors as list($lineNumber, $targetMethodName, $callingClass, $callableFromClasses)) {
+            $expectedIssues[] = [
+                "$targetMethodName cannot be called from {$callingClass}, it can only be called from classes: {$callableFromClasses}",
+                $lineNumber,
+            ];
+        }
+
+        $this->analyse([$file], $expectedIssues);
+    }
+
+    final protected function assertNoErrorsReported(string $file): void
+    {
+        $this->analyse([$file], []);
+    }
+}

--- a/tests/Rules/AbstractNamespaceVisibilityRuleTest.php
+++ b/tests/Rules/AbstractNamespaceVisibilityRuleTest.php
@@ -1,0 +1,38 @@
+<?php
+
+declare(strict_types=1);
+
+namespace DaveLiddament\PhpstanPhpLanguageExtensions\Tests\Rules;
+
+use PHPStan\Rules\Rule;
+use PHPStan\Testing\RuleTestCase;
+
+/**
+ * @template TRule of Rule
+ * @extends RuleTestCase<TRule>
+ */
+abstract class AbstractNamespaceVisibilityRuleTest extends RuleTestCase
+{
+    /** @param array<int,array{int,string,string, bool}> $errors */
+    final protected function assertErrorsReported(string $file, array $errors): void
+    {
+        $expectedIssues = [];
+        foreach ($errors as list($lineNumber, $targetMethodName, $namespace, $subNamespacesAllowed)) {
+            $issue = "$targetMethodName has Namespace Visibility, it can only be called from namespace $namespace";
+            if ($subNamespacesAllowed) {
+                $issue .= " and sub-namespaces of $namespace";
+            }
+            $expectedIssues[] = [
+                $issue,
+                $lineNumber,
+            ];
+        }
+
+        $this->analyse([$file], $expectedIssues);
+    }
+
+    final protected function assertNoErrorsReported(string $file): void
+    {
+        $this->analyse([$file], []);
+    }
+}

--- a/tests/Rules/CallableFromOnClassTest.php
+++ b/tests/Rules/CallableFromOnClassTest.php
@@ -1,0 +1,52 @@
+<?php
+
+declare(strict_types=1);
+
+namespace DaveLiddament\PhpstanPhpLanguageExtensions\Tests\Rules;
+
+use DaveLiddament\PhpstanPhpLanguageExtensions\Config\TestConfig;
+use DaveLiddament\PhpstanPhpLanguageExtensions\Rules\CallableFromMethodCallRule;
+use PHPStan\Rules\Rule;
+
+/** @extends AbstractCallableFromRuleTest<CallableFromMethodCallRule> */
+class CallableFromOnClassTest extends AbstractCallableFromRuleTest
+{
+    protected function getRule(): Rule
+    {
+        return new CallableFromMethodCallRule(
+            $this->createReflectionProvider(),
+            new TestConfig(TestConfig::NONE),
+        );
+    }
+
+    public function testMethodCall(): void
+    {
+        $this->assertErrorsReported(
+            __DIR__.'/data/callableFrom/callableFromOnClass.php',
+            [
+                [
+                    27,
+                    'CallableFromOnClass\Person::updateName',
+                    'CallableFromOnClass\Updater',
+                    'CallableFromOnClass\CallableFromUpdater',
+                ],
+                [
+                    32,
+                    'CallableFromOnClass\Person::updateName',
+                    '<no class>',
+                    'CallableFromOnClass\CallableFromUpdater',
+                ],
+            ],
+        );
+    }
+
+    public function testMultipleCallableFroms(): void
+    {
+        $this->assertNoErrorsReported(__DIR__.'/data/callableFrom/multipleCallableFrom.php');
+    }
+
+    public function testDifferentNamespace(): void
+    {
+        $this->assertNoErrorsReported(__DIR__.'/data/callableFrom/callableFromOnDifferentNamespace.php');
+    }
+}

--- a/tests/Rules/CallableFromOnConstructorTest.php
+++ b/tests/Rules/CallableFromOnConstructorTest.php
@@ -1,0 +1,42 @@
+<?php
+
+declare(strict_types=1);
+
+namespace DaveLiddament\PhpstanPhpLanguageExtensions\Tests\Rules;
+
+use DaveLiddament\PhpstanPhpLanguageExtensions\Config\TestConfig;
+use DaveLiddament\PhpstanPhpLanguageExtensions\Rules\CallableFromNewCallRule;
+use PHPStan\Rules\Rule;
+
+/** @extends AbstractCallableFromRuleTest<CallableFromNewCallRule> */
+class CallableFromOnConstructorTest extends AbstractCallableFromRuleTest
+{
+    protected function getRule(): Rule
+    {
+        return new CallableFromNewCallRule(
+            $this->createReflectionProvider(),
+            new TestConfig(TestConfig::NONE),
+        );
+    }
+
+    public function testStaticCall(): void
+    {
+        $this->assertErrorsReported(
+            __DIR__.'/data/callableFrom/callableFromOnConstructor.php',
+            [
+                [
+                    24,
+                    'CallableFromOnConstructor\Person::__construct',
+                    'CallableFromOnConstructor\Exam',
+                    'CallableFromOnConstructor\PersonBuilder',
+                ],
+                [
+                    28,
+                    'CallableFromOnConstructor\Person::__construct',
+                    '<no class>',
+                    'CallableFromOnConstructor\PersonBuilder',
+                ],
+            ]
+        );
+    }
+}

--- a/tests/Rules/CallableFromOnInterfaceClassTest.php
+++ b/tests/Rules/CallableFromOnInterfaceClassTest.php
@@ -1,0 +1,36 @@
+<?php
+
+declare(strict_types=1);
+
+namespace DaveLiddament\PhpstanPhpLanguageExtensions\Tests\Rules;
+
+use DaveLiddament\PhpstanPhpLanguageExtensions\Config\TestConfig;
+use DaveLiddament\PhpstanPhpLanguageExtensions\Rules\CallableFromMethodCallRule;
+use PHPStan\Rules\Rule;
+
+/** @extends AbstractCallableFromRuleTest<CallableFromMethodCallRule> */
+class CallableFromOnInterfaceClassTest extends AbstractCallableFromRuleTest
+{
+    protected function getRule(): Rule
+    {
+        return new CallableFromMethodCallRule(
+            $this->createReflectionProvider(),
+            new TestConfig(TestConfig::NONE),
+        );
+    }
+
+    public function testMethodCall(): void
+    {
+        $this->assertErrorsReported(
+            __DIR__.'/data/callableFrom/callableFromOnInterfaceClass.php',
+            [
+                [
+                    38,
+                    'CallableFromOnInterfaceClass\MessageSender::sendMessage',
+                    'CallableFromOnInterfaceClass\Foo',
+                    'CallableFromOnInterfaceClass\MessageSendingService',
+                ],
+            ],
+        );
+    }
+}

--- a/tests/Rules/CallableFromOnInterfaceMethodTest.php
+++ b/tests/Rules/CallableFromOnInterfaceMethodTest.php
@@ -1,0 +1,36 @@
+<?php
+
+declare(strict_types=1);
+
+namespace DaveLiddament\PhpstanPhpLanguageExtensions\Tests\Rules;
+
+use DaveLiddament\PhpstanPhpLanguageExtensions\Config\TestConfig;
+use DaveLiddament\PhpstanPhpLanguageExtensions\Rules\CallableFromMethodCallRule;
+use PHPStan\Rules\Rule;
+
+/** @extends AbstractCallableFromRuleTest<CallableFromMethodCallRule> */
+class CallableFromOnInterfaceMethodTest extends AbstractCallableFromRuleTest
+{
+    protected function getRule(): Rule
+    {
+        return new CallableFromMethodCallRule(
+            $this->createReflectionProvider(),
+            new TestConfig(TestConfig::NONE),
+        );
+    }
+
+    public function testMethodCall(): void
+    {
+        $this->assertErrorsReported(
+            __DIR__.'/data/callableFrom/callableFromOnInterfaceMethod.php',
+            [
+                [
+                    38,
+                    'CallableFromOnInterfaceMethod\MessageSender::sendMessage',
+                    'CallableFromOnInterfaceMethod\Foo',
+                    'CallableFromOnInterfaceMethod\MessageSendingService',
+                ],
+            ],
+        );
+    }
+}

--- a/tests/Rules/CallableFromOnNewTest.php
+++ b/tests/Rules/CallableFromOnNewTest.php
@@ -1,0 +1,42 @@
+<?php
+
+declare(strict_types=1);
+
+namespace DaveLiddament\PhpstanPhpLanguageExtensions\Tests\Rules;
+
+use DaveLiddament\PhpstanPhpLanguageExtensions\Config\TestConfig;
+use DaveLiddament\PhpstanPhpLanguageExtensions\Rules\CallableFromNewCallRule;
+use PHPStan\Rules\Rule;
+
+/** @extends AbstractCallableFromRuleTest<CallableFromNewCallRule> */
+class CallableFromOnNewTest extends AbstractCallableFromRuleTest
+{
+    protected function getRule(): Rule
+    {
+        return new CallableFromNewCallRule(
+            $this->createReflectionProvider(),
+            new TestConfig(TestConfig::NONE),
+        );
+    }
+
+    public function testStaticCall(): void
+    {
+        $this->assertErrorsReported(
+            __DIR__.'/data/callableFrom/callableFromOnNew.php',
+            [
+                [
+                    20,
+                    'CallableFromOnNew\Person::__construct',
+                    'CallableFromOnNew\Exam',
+                    'CallableFromOnNew\PersonBuilder',
+                ],
+                [
+                    24,
+                    'CallableFromOnNew\Person::__construct',
+                    '<no class>',
+                    'CallableFromOnNew\PersonBuilder',
+                ],
+            ]
+        );
+    }
+}

--- a/tests/Rules/CallableFromRuleMethodCallTest.php
+++ b/tests/Rules/CallableFromRuleMethodCallTest.php
@@ -1,0 +1,52 @@
+<?php
+
+declare(strict_types=1);
+
+namespace DaveLiddament\PhpstanPhpLanguageExtensions\Tests\Rules;
+
+use DaveLiddament\PhpstanPhpLanguageExtensions\Config\TestConfig;
+use DaveLiddament\PhpstanPhpLanguageExtensions\Rules\CallableFromMethodCallRule;
+use PHPStan\Rules\Rule;
+
+/** @extends AbstractCallableFromRuleTest<CallableFromMethodCallRule> */
+class CallableFromRuleMethodCallTest extends AbstractCallableFromRuleTest
+{
+    protected function getRule(): Rule
+    {
+        return new CallableFromMethodCallRule(
+            $this->createReflectionProvider(),
+            new TestConfig(TestConfig::NONE),
+        );
+    }
+
+    public function testMethodCall(): void
+    {
+        $this->assertErrorsReported(
+            __DIR__.'/data/callableFrom/callableFromOnMethod.php',
+            [
+                [
+                    26,
+                    'CallableFromOnMethod\Person::updateName',
+                    'CallableFromOnMethod\Updater',
+                    'CallableFromOnMethod\CallableFromUpdater',
+                ],
+                [
+                    31,
+                    'CallableFromOnMethod\Person::updateName',
+                    '<no class>',
+                    'CallableFromOnMethod\CallableFromUpdater',
+                ],
+            ],
+        );
+    }
+
+    public function testMultipleCallableFroms(): void
+    {
+        $this->assertNoErrorsReported(__DIR__.'/data/callableFrom/multipleCallableFrom.php');
+    }
+
+    public function testDifferentNamespace(): void
+    {
+        $this->assertNoErrorsReported(__DIR__.'/data/callableFrom/callableFromOnDifferentNamespace.php');
+    }
+}

--- a/tests/Rules/CallableFromRuleStaticCallTest.php
+++ b/tests/Rules/CallableFromRuleStaticCallTest.php
@@ -1,0 +1,42 @@
+<?php
+
+declare(strict_types=1);
+
+namespace DaveLiddament\PhpstanPhpLanguageExtensions\Tests\Rules;
+
+use DaveLiddament\PhpstanPhpLanguageExtensions\Config\TestConfig;
+use DaveLiddament\PhpstanPhpLanguageExtensions\Rules\CallableFromStaticCallRule;
+use PHPStan\Rules\Rule;
+
+/** @extends AbstractCallableFromRuleTest<CallableFromStaticCallRule> */
+class CallableFromRuleStaticCallTest extends AbstractCallableFromRuleTest
+{
+    protected function getRule(): Rule
+    {
+        return new CallableFromStaticCallRule(
+            $this->createReflectionProvider(),
+            new TestConfig(TestConfig::NONE),
+        );
+    }
+
+    public function testStaticCall(): void
+    {
+        $this->assertErrorsReported(
+            __DIR__.'/data/callableFrom/callableFromOnStaticMethod.php',
+            [
+                [
+                    24,
+                    'CallableFromOnStaticMethod\Person::updateName',
+                    'CallableFromOnStaticMethod\Updater',
+                    'CallableFromOnStaticMethod\CallableFromUpdater',
+                ],
+                [
+                    28,
+                    'CallableFromOnStaticMethod\Person::updateName',
+                    '<no class>',
+                    'CallableFromOnStaticMethod\CallableFromUpdater',
+                ],
+            ]
+        );
+    }
+}

--- a/tests/Rules/CallableFromWithTestClassNameTest.php
+++ b/tests/Rules/CallableFromWithTestClassNameTest.php
@@ -1,0 +1,28 @@
+<?php
+
+declare(strict_types=1);
+
+namespace DaveLiddament\PhpstanPhpLanguageExtensions\Tests\Rules;
+
+use DaveLiddament\PhpstanPhpLanguageExtensions\Config\TestConfig;
+use DaveLiddament\PhpstanPhpLanguageExtensions\Rules\CallableFromMethodCallRule;
+use PHPStan\Rules\Rule;
+
+/** @extends AbstractPackageRuleTest<CallableFromMethodCallRule> */
+class CallableFromWithTestClassNameTest extends AbstractPackageRuleTest
+{
+    protected function getRule(): Rule
+    {
+        return new CallableFromMethodCallRule(
+            $this->createReflectionProvider(),
+            new TestConfig(
+                mode: TestConfig::CLASS_NAME,
+            ),
+        );
+    }
+
+    public function testCallsFromTestClass(): void
+    {
+        $this->assertNoErrorsReported(__DIR__.'/data/callableFrom/callableFromRulesIgnoredForTestClass.php');
+    }
+}

--- a/tests/Rules/CallableFromWithTestNamespaceTest.php
+++ b/tests/Rules/CallableFromWithTestNamespaceTest.php
@@ -1,0 +1,29 @@
+<?php
+
+declare(strict_types=1);
+
+namespace DaveLiddament\PhpstanPhpLanguageExtensions\Tests\Rules;
+
+use DaveLiddament\PhpstanPhpLanguageExtensions\Config\TestConfig;
+use DaveLiddament\PhpstanPhpLanguageExtensions\Rules\CallableFromMethodCallRule;
+use PHPStan\Rules\Rule;
+
+/** @extends AbstractPackageRuleTest<CallableFromMethodCallRule> */
+class CallableFromWithTestNamespaceTest extends AbstractPackageRuleTest
+{
+    protected function getRule(): Rule
+    {
+        return new CallableFromMethodCallRule(
+            $this->createReflectionProvider(),
+            new TestConfig(
+                mode: TestConfig::NAMESPACE,
+                testNamespace: 'CallableFromRulesIgnoredForTestNamespace\Test'
+            ),
+        );
+    }
+
+    public function testCallsFromTestClass(): void
+    {
+        $this->assertNoErrorsReported(__DIR__.'/data/callableFrom/callableFromRulesIgnoredForTestNamespace.php');
+    }
+}

--- a/tests/Rules/NamespaceVisibilityOnClassTest.php
+++ b/tests/Rules/NamespaceVisibilityOnClassTest.php
@@ -1,0 +1,36 @@
+<?php
+
+declare(strict_types=1);
+
+namespace DaveLiddament\PhpstanPhpLanguageExtensions\Tests\Rules;
+
+use DaveLiddament\PhpstanPhpLanguageExtensions\Config\TestConfig;
+use DaveLiddament\PhpstanPhpLanguageExtensions\Rules\NamespaceVisibilityMethodCallRule;
+use PHPStan\Rules\Rule;
+
+/** @extends AbstractNamespaceVisibilityRuleTest<NamespaceVisibilityMethodCallRule> */
+class NamespaceVisibilityOnClassTest extends AbstractNamespaceVisibilityRuleTest
+{
+    protected function getRule(): Rule
+    {
+        return new NamespaceVisibilityMethodCallRule(
+            $this->createReflectionProvider(),
+            new TestConfig(TestConfig::NONE),
+        );
+    }
+
+    public function testMethodCall(): void
+    {
+        $this->assertErrorsReported(
+            __DIR__.'/data/namespaceVisibility/namespaceVisibilityOnClass.php',
+            [
+                [
+                    61,
+                    'NamespaceVisibilityOnClass\Person::updateName',
+                    'NamespaceVisibilityOnClass',
+                    true,
+                ],
+            ],
+        );
+    }
+}

--- a/tests/Rules/NamespaceVisibilityOnClassTest.php
+++ b/tests/Rules/NamespaceVisibilityOnClassTest.php
@@ -33,4 +33,26 @@ class NamespaceVisibilityOnClassTest extends AbstractNamespaceVisibilityRuleTest
             ],
         );
     }
+
+    public function testExcludeSubNamespaces(): void
+    {
+        $this->assertErrorsReported(
+            __DIR__.'/data/namespaceVisibility/namespaceVisibilityOnClassExcludeSubNamespaces.php',
+            [
+                [
+                    30,
+                    'NamespaceVisibilityOnClassExcludeSubNamespaces\Person::updateName',
+                    'NamespaceVisibilityOnClassExcludeSubNamespaces',
+                    false,
+                ],
+            ],
+        );
+    }
+
+    public function testForDifferentNamespace(): void
+    {
+        $this->assertNoErrorsReported(
+            __DIR__.'/data/namespaceVisibility/namespaceVisibilityOnClassForDifferentNamespaces.php',
+        );
+    }
 }

--- a/tests/Rules/NamespaceVisibilityOnConstructorTest.php
+++ b/tests/Rules/NamespaceVisibilityOnConstructorTest.php
@@ -1,0 +1,58 @@
+<?php
+
+declare(strict_types=1);
+
+namespace DaveLiddament\PhpstanPhpLanguageExtensions\Tests\Rules;
+
+use DaveLiddament\PhpstanPhpLanguageExtensions\Config\TestConfig;
+use DaveLiddament\PhpstanPhpLanguageExtensions\Rules\NamespaceVisibilityNewCallRule;
+use PHPStan\Rules\Rule;
+
+/** @extends AbstractNamespaceVisibilityRuleTest<NamespaceVisibilityNewCallRule> */
+class NamespaceVisibilityOnConstructorTest extends AbstractNamespaceVisibilityRuleTest
+{
+    protected function getRule(): Rule
+    {
+        return new NamespaceVisibilityNewCallRule(
+            $this->createReflectionProvider(),
+            new TestConfig(TestConfig::NONE),
+        );
+    }
+
+    public function testMethodCall(): void
+    {
+        $this->assertErrorsReported(
+            __DIR__.'/data/namespaceVisibility/namespaceVisibilityOnConstructor.php',
+            [
+                [
+                    55,
+                    'NamespaceVisibilityOnConstructor\Person::__construct',
+                    'NamespaceVisibilityOnConstructor',
+                    true,
+                ],
+            ],
+        );
+    }
+
+    public function testExcludeSubNamespace(): void
+    {
+        $this->assertErrorsReported(
+            __DIR__.'/data/namespaceVisibility/namespaceVisibilityOnConstructorExcludeSubNamespaces.php',
+            [
+                [
+                    40,
+                    'NamespaceVisibilityOnConstructorExcludeSubNamespaces\Person::__construct',
+                    'NamespaceVisibilityOnConstructorExcludeSubNamespaces',
+                    false,
+                ],
+            ],
+        );
+    }
+
+    public function testForDifferentNamespace(): void
+    {
+        $this->assertNoErrorsReported(
+            __DIR__.'/data/namespaceVisibility/namespaceVisibilityOnConstructorForDifferentNamespaces.php'
+        );
+    }
+}

--- a/tests/Rules/NamespaceVisibilityOnMethodTest.php
+++ b/tests/Rules/NamespaceVisibilityOnMethodTest.php
@@ -1,0 +1,58 @@
+<?php
+
+declare(strict_types=1);
+
+namespace DaveLiddament\PhpstanPhpLanguageExtensions\Tests\Rules;
+
+use DaveLiddament\PhpstanPhpLanguageExtensions\Config\TestConfig;
+use DaveLiddament\PhpstanPhpLanguageExtensions\Rules\NamespaceVisibilityMethodCallRule;
+use PHPStan\Rules\Rule;
+
+/** @extends AbstractNamespaceVisibilityRuleTest<NamespaceVisibilityMethodCallRule> */
+class NamespaceVisibilityOnMethodTest extends AbstractNamespaceVisibilityRuleTest
+{
+    protected function getRule(): Rule
+    {
+        return new NamespaceVisibilityMethodCallRule(
+            $this->createReflectionProvider(),
+            new TestConfig(TestConfig::NONE),
+        );
+    }
+
+    public function testMethodCall(): void
+    {
+        $this->assertErrorsReported(
+            __DIR__.'/data/namespaceVisibility/namespaceVisibilityOnMethod.php',
+            [
+                [
+                    58,
+                    'NamespaceVisibilityOnMethod\Person::updateName',
+                    'NamespaceVisibilityOnMethod',
+                    true,
+                ],
+            ],
+        );
+    }
+
+    public function testExcludeSubNamespace(): void
+    {
+        $this->assertErrorsReported(
+            __DIR__.'/data/namespaceVisibility/namespaceVisibilityOnMethodExcludeSubNamespace.php',
+            [
+                [
+                    32,
+                    'NamespaceVisibilityOnMethodExcludeSubNamespace\Person::updateName',
+                    'NamespaceVisibilityOnMethodExcludeSubNamespace',
+                    false,
+                ],
+            ],
+        );
+    }
+
+    public function testForDifferentNamespace(): void
+    {
+        $this->assertNoErrorsReported(
+            __DIR__.'/data/namespaceVisibility/namespaceVisibilityOnMethodForDifferentNamespace.php'
+        );
+    }
+}

--- a/tests/Rules/NamespaceVisibilityOnNewTest.php
+++ b/tests/Rules/NamespaceVisibilityOnNewTest.php
@@ -1,0 +1,58 @@
+<?php
+
+declare(strict_types=1);
+
+namespace DaveLiddament\PhpstanPhpLanguageExtensions\Tests\Rules;
+
+use DaveLiddament\PhpstanPhpLanguageExtensions\Config\TestConfig;
+use DaveLiddament\PhpstanPhpLanguageExtensions\Rules\NamespaceVisibilityNewCallRule;
+use PHPStan\Rules\Rule;
+
+/** @extends AbstractNamespaceVisibilityRuleTest<NamespaceVisibilityNewCallRule> */
+class NamespaceVisibilityOnNewTest extends AbstractNamespaceVisibilityRuleTest
+{
+    protected function getRule(): Rule
+    {
+        return new NamespaceVisibilityNewCallRule(
+            $this->createReflectionProvider(),
+            new TestConfig(TestConfig::NONE),
+        );
+    }
+
+    public function testMethodCall(): void
+    {
+        $this->assertErrorsReported(
+            __DIR__.'/data/namespaceVisibility/namespaceVisibilityOnNew.php',
+            [
+                [
+                    54,
+                    'NamespaceVisibilityOnNew\Person::__construct',
+                    'NamespaceVisibilityOnNew',
+                    true,
+                ],
+            ],
+        );
+    }
+
+    public function testExcludeSubNamespace(): void
+    {
+        $this->assertErrorsReported(
+            __DIR__.'/data/namespaceVisibility/namespaceVisibilityOnNewExcludeSubNamespaces.php',
+            [
+                [
+                    40,
+                    'NamespaceVisibilityOnNewExcludeSubNamespaces\Person::__construct',
+                    'NamespaceVisibilityOnNewExcludeSubNamespaces',
+                    false,
+                ],
+            ],
+        );
+    }
+
+    public function testForDifferentNamespace(): void
+    {
+        $this->assertNoErrorsReported(
+            __DIR__.'/data/namespaceVisibility/namespaceVisibilityOnNewForDifferentNamespaces.php'
+        );
+    }
+}

--- a/tests/Rules/NamespaceVisibilityOnStaticTest.php
+++ b/tests/Rules/NamespaceVisibilityOnStaticTest.php
@@ -1,0 +1,58 @@
+<?php
+
+declare(strict_types=1);
+
+namespace DaveLiddament\PhpstanPhpLanguageExtensions\Tests\Rules;
+
+use DaveLiddament\PhpstanPhpLanguageExtensions\Config\TestConfig;
+use DaveLiddament\PhpstanPhpLanguageExtensions\Rules\NamespaceVisibilityStaticCallRule;
+use PHPStan\Rules\Rule;
+
+/** @extends AbstractNamespaceVisibilityRuleTest<NamespaceVisibilityStaticCallRule> */
+class NamespaceVisibilityOnStaticTest extends AbstractNamespaceVisibilityRuleTest
+{
+    protected function getRule(): Rule
+    {
+        return new NamespaceVisibilityStaticCallRule(
+            $this->createReflectionProvider(),
+            new TestConfig(TestConfig::NONE),
+        );
+    }
+
+    public function testStaticMethodCall(): void
+    {
+        $this->assertErrorsReported(
+            __DIR__.'/data/namespaceVisibility/namespaceVisibilityOnStaticMethod.php',
+            [
+                [
+                    52,
+                    'NamespaceVisibilityOnStaticMethod\Person::updateName',
+                    'NamespaceVisibilityOnStaticMethod',
+                    true,
+                ],
+            ],
+        );
+    }
+
+    public function testExcludeSubNamespace(): void
+    {
+        $this->assertErrorsReported(
+            __DIR__.'/data/namespaceVisibility/namespaceVisibilityOnStaticMethodExcludeSubNamespaces.php',
+            [
+                [
+                    26,
+                    'NamespaceVisibilityOnStaticMethodExcludeSubNamespaces\Person::updateName',
+                    'NamespaceVisibilityOnStaticMethodExcludeSubNamespaces',
+                    false,
+                ],
+            ],
+        );
+    }
+
+    public function testForDifferentNamespace(): void
+    {
+        $this->assertNoErrorsReported(
+            __DIR__.'/data/namespaceVisibility/namespaceVisibilityOnStaticMethodForDifferentNamespaces.php'
+        );
+    }
+}

--- a/tests/Rules/NamespaceVisibilityWithTestClassNameTest.php
+++ b/tests/Rules/NamespaceVisibilityWithTestClassNameTest.php
@@ -1,0 +1,28 @@
+<?php
+
+declare(strict_types=1);
+
+namespace DaveLiddament\PhpstanPhpLanguageExtensions\Tests\Rules;
+
+use DaveLiddament\PhpstanPhpLanguageExtensions\Config\TestConfig;
+use DaveLiddament\PhpstanPhpLanguageExtensions\Rules\NamespaceVisibilityMethodCallRule;
+use PHPStan\Rules\Rule;
+
+/** @extends AbstractNamespaceVisibilityRuleTest<NamespaceVisibilityMethodCallRule> */
+class NamespaceVisibilityWithTestClassNameTest extends AbstractNamespaceVisibilityRuleTest
+{
+    protected function getRule(): Rule
+    {
+        return new NamespaceVisibilityMethodCallRule(
+            $this->createReflectionProvider(),
+            new TestConfig(
+                mode: TestConfig::CLASS_NAME,
+            ),
+        );
+    }
+
+    public function testCallsFromTestClass(): void
+    {
+        $this->assertNoErrorsReported(__DIR__.'/data/namespaceVisibility/namespaceVisibilityRulesIgnoredForTestClass.php');
+    }
+}

--- a/tests/Rules/NamespaceVisibilityWithTestNamespaceTest.php
+++ b/tests/Rules/NamespaceVisibilityWithTestNamespaceTest.php
@@ -1,0 +1,29 @@
+<?php
+
+declare(strict_types=1);
+
+namespace DaveLiddament\PhpstanPhpLanguageExtensions\Tests\Rules;
+
+use DaveLiddament\PhpstanPhpLanguageExtensions\Config\TestConfig;
+use DaveLiddament\PhpstanPhpLanguageExtensions\Rules\NamespaceVisibilityMethodCallRule;
+use PHPStan\Rules\Rule;
+
+/** @extends AbstractNamespaceVisibilityRuleTest<NamespaceVisibilityMethodCallRule> */
+class NamespaceVisibilityWithTestNamespaceTest extends AbstractNamespaceVisibilityRuleTest
+{
+    protected function getRule(): Rule
+    {
+        return new NamespaceVisibilityMethodCallRule(
+            $this->createReflectionProvider(),
+            new TestConfig(
+                mode: TestConfig::NAMESPACE,
+                testNamespace: 'NamespaceVisibilityRulesIgnoredForTestNamespace\Test'
+            ),
+        );
+    }
+
+    public function testCallsFromTestClass(): void
+    {
+        $this->assertNoErrorsReported(__DIR__.'/data/namespaceVisibility/namespaceVisibilityRulesIgnoredForTestNamespace.php');
+    }
+}

--- a/tests/Rules/data/callableFrom/callableFromOnClass.php
+++ b/tests/Rules/data/callableFrom/callableFromOnClass.php
@@ -1,0 +1,41 @@
+<?php
+
+declare(strict_types=1);
+
+namespace CallableFromOnClass;
+
+use DaveLiddament\PhpLanguageExtensions\CallableFrom;
+
+
+#[CallableFrom(CallableFromUpdater::class)]
+class Person
+{
+    public function updateName(): void
+    {
+    }
+
+    public function update(): void
+    {
+        $this->updateName(); // OK
+    }
+}
+
+class Updater
+{
+    public function updater(Person $person): void
+    {
+        $person->updateName(); // ERROR: Updater is not a CallableFrom of Person
+    }
+}
+
+$person = new Person();
+$person->updateName(); // ERROR
+
+class CallableFromUpdater
+{
+    public function update(): void
+    {
+        $person = new Person();
+        $person->updateName(); // OK
+    }
+}

--- a/tests/Rules/data/callableFrom/callableFromOnConstructor.php
+++ b/tests/Rules/data/callableFrom/callableFromOnConstructor.php
@@ -1,0 +1,36 @@
+<?php
+
+namespace CallableFromOnConstructor;
+
+use DaveLiddament\PhpLanguageExtensions\CallableFrom;
+
+class Person
+{
+    #[CallableFrom(PersonBuilder::class)]
+    public function __construct()
+    {
+    }
+
+    public static function create(): Person
+    {
+        return new Person(); // OK: Method calls on same class always allowed.
+    }
+}
+
+class Exam
+{
+    public function addPerson(): void
+    {
+        new Person(); // ERROR: Exam is not a CallableFrom of Person::__construct
+    }
+}
+
+new Person(); // ERROR
+
+class PersonBuilder
+{
+    public function build(): Person
+    {
+        return new Person(); // OK: PersonBuilder is a callableFrom of Person::__construct
+    }
+}

--- a/tests/Rules/data/callableFrom/callableFromOnDifferentNamespace.php
+++ b/tests/Rules/data/callableFrom/callableFromOnDifferentNamespace.php
@@ -1,0 +1,26 @@
+<?php
+
+namespace CallableFromOnDifferentNamespace1 {
+    use DaveLiddament\PhpLanguageExtensions\CallableFrom;
+    use CallableFromOnDifferentNamespace2\Builder;
+
+    class Employee
+    {
+        #[CallableFrom(Builder::class)]
+        public function update(): void
+        {
+        }
+    }
+}
+
+namespace CallableFromOnDifferentNamespace2 {
+    use CallableFromOnDifferentNamespace1\Employee;
+
+    class Builder
+    {
+        public function update(Employee $employee): void
+        {
+            $employee->update(); // OK: Builder a callableFrom of Employee
+        }
+    }
+}

--- a/tests/Rules/data/callableFrom/callableFromOnInterfaceClass.php
+++ b/tests/Rules/data/callableFrom/callableFromOnInterfaceClass.php
@@ -1,0 +1,40 @@
+<?php
+
+namespace CallableFromOnInterfaceClass;
+
+use DaveLiddament\PhpLanguageExtensions\CallableFrom;
+
+#[CallableFrom(MessageSendingService::class)]
+interface MessageSender
+{
+    public function sendMessage(): void;
+}
+
+
+class PhpMailerMessageSender implements MessageSender
+{
+    public function sendMessage(): void
+    {
+    }
+}
+
+
+class MessageSendingService
+{
+    public function __construct(public MessageSender $messageSender) {}
+
+    public function sendMessage(): void
+    {
+        $this->messageSender->sendMessage(); // OK
+    }
+}
+
+class Foo
+{
+    public function __construct(public MessageSender $messageSender) {}
+
+    public function sendMessage(): void
+    {
+        $this->messageSender->sendMessage(); // ERROR Foo is not a callableFrom of MessageSender
+    }
+}

--- a/tests/Rules/data/callableFrom/callableFromOnInterfaceMethod.php
+++ b/tests/Rules/data/callableFrom/callableFromOnInterfaceMethod.php
@@ -1,0 +1,40 @@
+<?php
+
+namespace CallableFromOnInterfaceMethod;
+
+use DaveLiddament\PhpLanguageExtensions\CallableFrom;
+
+interface MessageSender
+{
+    #[CallableFrom(MessageSendingService::class)]
+    public function sendMessage(): void;
+}
+
+
+class PhpMailerMessageSender implements MessageSender
+{
+    public function sendMessage(): void
+    {
+    }
+}
+
+
+class MessageSendingService
+{
+    public function __construct(public MessageSender $messageSender) {}
+
+    public function sendMessage(): void
+    {
+        $this->messageSender->sendMessage(); // OK
+    }
+}
+
+class Foo
+{
+    public function __construct(public MessageSender $messageSender) {}
+
+    public function sendMessage(): void
+    {
+        $this->messageSender->sendMessage(); // ERROR Foo is not a callableFrom of MessageSender
+    }
+}

--- a/tests/Rules/data/callableFrom/callableFromOnMethod.php
+++ b/tests/Rules/data/callableFrom/callableFromOnMethod.php
@@ -1,0 +1,40 @@
+<?php
+
+declare(strict_types=1);
+
+namespace CallableFromOnMethod;
+
+use DaveLiddament\PhpLanguageExtensions\CallableFrom;
+
+class Person
+{
+    #[CallableFrom(CallableFromUpdater::class)]
+    public function updateName(): void
+    {
+    }
+
+    public function update(): void
+    {
+        $this->updateName(); // OK: Method calls on same class is always allowed
+    }
+}
+
+class Updater
+{
+    public function updater(Person $person): void
+    {
+        $person->updateName(); // ERROR: Updater is not a callableFrom of Person::updateName
+    }
+}
+
+$person = new Person();
+$person->updateName(); // ERROR: Global namespace is not a callableFrom of Person::updateName
+
+class CallableFromUpdater
+{
+    public function update(): void
+    {
+        $person = new Person();
+        $person->updateName(); // OK: CallableFromUpdater is a callableFrom of Person::updateName
+    }
+}

--- a/tests/Rules/data/callableFrom/callableFromOnNew.php
+++ b/tests/Rules/data/callableFrom/callableFromOnNew.php
@@ -1,0 +1,32 @@
+<?php
+
+namespace CallableFromOnNew;
+
+use DaveLiddament\PhpLanguageExtensions\CallableFrom;
+
+#[CallableFrom(PersonBuilder::class)]
+class Person
+{
+    public static function create(): Person
+    {
+        return new Person(); // OK
+    }
+}
+
+class Exam
+{
+    public function addPerson(): void
+    {
+        new Person(); // ERROR
+    }
+}
+
+new Person(); // ERROR
+
+class PersonBuilder
+{
+    public function build(): Person
+    {
+        return new Person(); // OK
+    }
+}

--- a/tests/Rules/data/callableFrom/callableFromOnStaticMethod.php
+++ b/tests/Rules/data/callableFrom/callableFromOnStaticMethod.php
@@ -1,0 +1,36 @@
+<?php
+
+namespace CallableFromOnStaticMethod;
+
+use DaveLiddament\PhpLanguageExtensions\CallableFrom;
+
+class Person
+{
+    #[CallableFrom(CallableFromUpdater::class)]
+    public static function updateName(): void
+    {
+    }
+
+    public static function update(): void
+    {
+        Person::updateName(); // OK: Method calls within class allowed
+    }
+}
+
+class Updater
+{
+    public function updater(): void
+    {
+        Person::updateName(); // ERROR: Updater is not a callableFrom of Person::updateName
+    }
+}
+
+Person::updateName(); // ERROR
+
+class CallableFromUpdater
+{
+    public function update(): void
+    {
+        Person::updateName(); // OK: CallableFromUpdater is a callableFrom of Person::updateName
+    }
+}

--- a/tests/Rules/data/callableFrom/callableFromRulesIgnoredForTestClass.php
+++ b/tests/Rules/data/callableFrom/callableFromRulesIgnoredForTestClass.php
@@ -1,0 +1,28 @@
+<?php
+
+declare(strict_types=1);
+
+namespace CallableFromRulesIgnoredForTestClass;
+
+use DaveLiddament\PhpLanguageExtensions\CallableFrom;
+
+
+#[CallableFrom(CallableFromUpdater::class)]
+class Person
+{
+    public function updateName(): void
+    {
+    }
+}
+
+class CallableFromUpdater
+{
+}
+
+class PersonTest
+{
+    public function updater(Person $person): void
+    {
+        $person->updateName(); // OK: calling from a class with a name ending Test
+    }
+}

--- a/tests/Rules/data/callableFrom/callableFromRulesIgnoredForTestNamespace.php
+++ b/tests/Rules/data/callableFrom/callableFromRulesIgnoredForTestNamespace.php
@@ -1,0 +1,38 @@
+<?php
+
+declare(strict_types=1);
+
+namespace CallableFromRulesIgnoredForTestNamespace {
+
+    use DaveLiddament\PhpLanguageExtensions\CallableFrom;
+
+
+    #[CallableFrom(CallableFromUpdater::class)]
+    class Person
+    {
+        public function updateName(): void
+        {
+        }
+    }
+
+    class CallableFromUpdater
+    {
+    }
+
+
+}
+
+
+namespace CallableFromRulesIgnoredForTestNamespace\Test\Person {
+
+    use CallableFromRulesIgnoredForTestNamespace\Person;
+
+    class PersonCheck
+    {
+        public function updater(Person $person): void
+        {
+            $person->updateName(); // OK: calling from a test namespace
+        }
+    }
+
+}

--- a/tests/Rules/data/callableFrom/multipleCallableFrom.php
+++ b/tests/Rules/data/callableFrom/multipleCallableFrom.php
@@ -1,0 +1,31 @@
+<?php
+
+declare(strict_types=1);
+
+namespace MultipleCallableFroms;
+
+use DaveLiddament\PhpLanguageExtensions\CallableFrom;
+
+class Person
+{
+    #[CallableFrom(CallableFromUpdater::class, AnotherCallableFromUpdater::class)]
+    public function updateName(): void
+    {
+    }
+}
+
+class CallableFromUpdater
+{
+    public function update(Person $person): void
+    {
+        $person->updateName(); // OK: CallableFromUpdater a callableFrom of Person::updateName
+    }
+}
+
+class AnotherCallableFromUpdater
+{
+    public function update(Person $person): void
+    {
+        $person->updateName(); // OK: AnotherCallableFromUpdater a callableFrom of Person::updateName
+    }
+}

--- a/tests/Rules/data/namespaceVisibility/namespaceVisibilityOnClass.php
+++ b/tests/Rules/data/namespaceVisibility/namespaceVisibilityOnClass.php
@@ -1,0 +1,64 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NamespaceVisibilityOnClass {
+
+    use DaveLiddament\PhpLanguageExtensions\NamespaceVisibility;
+
+
+    #[NamespaceVisibility]
+    class Person
+    {
+        public function updateName(): void
+        {
+        }
+
+        public function update(): void
+        {
+            $this->updateName(); // OK: Calls to same class allowed
+        }
+    }
+
+    class Updater
+    {
+        public function updater(Person $person): void
+        {
+            $person->updateName(); // OK: Calls within same namespace allowed
+        }
+    }
+
+    $person = new Person();
+    $person->updateName(); // OK: Calls within same namespace allowed
+
+}
+
+
+namespace NamespaceVisibilityOnClass\SubNamesapce {
+
+    use NamespaceVisibilityOnClass\Person;
+
+    class AnotherClass
+    {
+        public function update(): void
+        {
+            $person = new Person();
+            $person->updateName(); // OK: Calls within the same subnamespace allowed.
+        }
+    }
+}
+
+
+namespace NamespaceVisibilityOnClass2 {
+
+    use NamespaceVisibilityOnClass\Person;
+
+    class AnotherUpdater
+    {
+        public function update(): void
+        {
+            $person = new Person();
+            $person->updateName(); // ERROR: Call to Person::update method which has namespace visibility.
+        }
+    }
+}

--- a/tests/Rules/data/namespaceVisibility/namespaceVisibilityOnClassExcludeSubNamespaces.php
+++ b/tests/Rules/data/namespaceVisibility/namespaceVisibilityOnClassExcludeSubNamespaces.php
@@ -1,0 +1,33 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NamespaceVisibilityOnClassExcludeSubNamespaces {
+
+    use DaveLiddament\PhpLanguageExtensions\NamespaceVisibility;
+
+
+    #[NamespaceVisibility(excludeSubNamespaces: true)]
+    class Person
+    {
+        public function updateName(): void
+        {
+        }
+    }
+
+}
+
+
+namespace NamespaceVisibilityOnClassExcludeSubNamespace\SubNamesapce {
+
+    use NamespaceVisibilityOnClassExcludeSubNamespaces\Person;
+
+    class AnotherClass
+    {
+        public function update(): void
+        {
+            $person = new Person();
+            $person->updateName(); // ERROR: Call to Person::updateName in a sub namespace, where sub namespace is not allowed.
+        }
+    }
+}

--- a/tests/Rules/data/namespaceVisibility/namespaceVisibilityOnClassExcludeSubNamespaces.php
+++ b/tests/Rules/data/namespaceVisibility/namespaceVisibilityOnClassExcludeSubNamespaces.php
@@ -18,7 +18,7 @@ namespace NamespaceVisibilityOnClassExcludeSubNamespaces {
 }
 
 
-namespace NamespaceVisibilityOnClassExcludeSubNamespace\SubNamesapce {
+namespace NamespaceVisibilityOnClassExcludeSubNamespaces\SubNamespace {
 
     use NamespaceVisibilityOnClassExcludeSubNamespaces\Person;
 

--- a/tests/Rules/data/namespaceVisibility/namespaceVisibilityOnClassForDifferentNamespaces.php
+++ b/tests/Rules/data/namespaceVisibility/namespaceVisibilityOnClassForDifferentNamespaces.php
@@ -1,0 +1,33 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NamespaceVisibilityOnClassForDifferentNamespaces {
+
+    use DaveLiddament\PhpLanguageExtensions\NamespaceVisibility;
+
+
+    #[NamespaceVisibility(namespace: 'NamespaceVisibilityOnClassDifferentNamespace')]
+    class Person
+    {
+        public function updateName(): void
+        {
+        }
+    }
+
+}
+
+
+namespace NamespaceVisibilityOnClassDifferentNamespace {
+
+    use NamespaceVisibilityOnClassForDifferentNamespaces\Person;
+
+    class AnotherClass
+    {
+        public function update(): void
+        {
+            $person = new Person();
+            $person->updateName(); // OK: Call to Person::updateName is in the allowed namespace.
+        }
+    }
+}

--- a/tests/Rules/data/namespaceVisibility/namespaceVisibilityOnConstructor.php
+++ b/tests/Rules/data/namespaceVisibility/namespaceVisibilityOnConstructor.php
@@ -1,0 +1,58 @@
+<?php
+
+namespace NamespaceVisibilityOnConstructor {
+
+    use DaveLiddament\PhpLanguageExtensions\NamespaceVisibility;
+
+    class Person
+    {
+        #[NamespaceVisibility]
+        public function __construct()
+        {
+        }
+
+        public static function create(): Person
+        {
+            return new Person(); // OK: Calls to same class allowed.
+        }
+    }
+
+    class PersonBuilder
+    {
+        public function build(): Person
+        {
+            return new Person(); // OK: Calls within the same namespace allowed.
+        }
+    }
+
+    new Person(); // OK: Calls withing the same namespace allowed
+}
+
+
+namespace NamespaceVisibilityOnConstructor\SubNamespace {
+
+    use NamespaceVisibilityOnConstructor\Person;
+
+    class AnotherPersonBuilder
+    {
+        public function create(): void
+        {
+            new Person(); // OK, sub namespace of NamespaceVisibilityOnConstructor
+        }
+    }
+}
+
+
+
+namespace NamespaceVisibilityOnConstructor2 {
+
+    use NamespaceVisibilityOnConstructor\Person;
+
+    class Exam
+    {
+        public function addPerson(): void
+        {
+            new Person(); // ERROR: Call to Person::__construct has namespace visibility, this is a different namespace
+        }
+    }
+}

--- a/tests/Rules/data/namespaceVisibility/namespaceVisibilityOnConstructorExcludeSubNamespaces.php
+++ b/tests/Rules/data/namespaceVisibility/namespaceVisibilityOnConstructorExcludeSubNamespaces.php
@@ -1,0 +1,44 @@
+<?php
+
+namespace NamespaceVisibilityOnConstructorExcludeSubNamespaces {
+
+    use DaveLiddament\PhpLanguageExtensions\NamespaceVisibility;
+
+    class Person
+    {
+        #[NamespaceVisibility(excludeSubNamespaces: true)]
+        public function __construct()
+        {
+        }
+
+        public static function create(): Person
+        {
+            return new Person(); // OK: Calls to same class allowed.
+        }
+    }
+
+    class PersonBuilder
+    {
+        public function build(): Person
+        {
+            return new Person(); // OK: Calls within the same namespace allowed.
+        }
+    }
+
+    new Person(); // OK: Calls withing the same namespace allowed
+}
+
+
+namespace NamespaceVisibilityOnConstructorExcludeSubNamespace\SubNamespace {
+
+    use NamespaceVisibilityOnConstructorExcludeSubNamespaces\Person;
+
+    class AnotherPersonBuilder
+    {
+        public function create(): void
+        {
+            new Person(); // Error, sub namespace of NamespaceVisibilityOnConstructor and this is not allowed
+        }
+    }
+}
+

--- a/tests/Rules/data/namespaceVisibility/namespaceVisibilityOnConstructorForDifferentNamespaces.php
+++ b/tests/Rules/data/namespaceVisibility/namespaceVisibilityOnConstructorForDifferentNamespaces.php
@@ -1,0 +1,30 @@
+<?php
+
+namespace NamespaceVisibilityOnConstructorForDifferentNamespaces {
+
+    use DaveLiddament\PhpLanguageExtensions\NamespaceVisibility;
+
+    class Person
+    {
+        #[NamespaceVisibility(namespace: 'NamespaceVisibilityOnConstructorDifferentNamespace')]
+        public function __construct()
+        {
+        }
+
+    }
+}
+
+
+namespace NamespaceVisibilityOnConstructorDifferentNamespace {
+
+    use NamespaceVisibilityOnConstructorForDifferentNamespaces\Person;
+
+    class AnotherPersonBuilder
+    {
+        public function create(): void
+        {
+            new Person(); // OK, called to Person::__construct from allowed namespace.
+        }
+    }
+}
+

--- a/tests/Rules/data/namespaceVisibility/namespaceVisibilityOnMethod.php
+++ b/tests/Rules/data/namespaceVisibility/namespaceVisibilityOnMethod.php
@@ -1,0 +1,61 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NamespaceVisibilityOnMethod {
+
+    use DaveLiddament\PhpLanguageExtensions\NamespaceVisibility;
+
+    class Person
+    {
+        #[NamespaceVisibility]
+        public function updateName(): void
+        {
+        }
+
+        public function update(): void
+        {
+            $this->updateName(); // OK
+        }
+    }
+
+    class Updater
+    {
+        public function updater(Person $person): void
+        {
+            $person->updateName(); // OK
+        }
+    }
+
+    $person = new Person();
+    $person->updateName(); // OK
+}
+
+
+
+namespace NamespaceVisibilityOnMethod\SubNamespace {
+
+    use NamespaceVisibilityOnMethod\Person;
+    class AnotherPersonUpdater
+    {
+        public function update(Person $person): void
+        {
+            $person->updateName(); // OK - Subnamespace of NamespaceVisibilityOnMethod, which is allowed
+        }
+    }
+}
+
+
+namespace NamespaceVisibilityOnMethod2 {
+
+    use NamespaceVisibilityOnMethod\Person;
+
+    class AnotherUpdater
+    {
+        public function update(): void
+        {
+            $person = new Person();
+            $person->updateName(); // ERROR: Call to Person::updateName which has namespaceVisibility visibility
+        }
+    }
+}

--- a/tests/Rules/data/namespaceVisibility/namespaceVisibilityOnMethodExcludeSubNamespace.php
+++ b/tests/Rules/data/namespaceVisibility/namespaceVisibilityOnMethodExcludeSubNamespace.php
@@ -1,0 +1,36 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NamespaceVisibilityOnMethodExcludeSubNamespace {
+
+    use DaveLiddament\PhpLanguageExtensions\NamespaceVisibility;
+
+    class Person
+    {
+        #[NamespaceVisibility(excludeSubNamespaces: true)]
+        public function updateName(): void
+        {
+        }
+
+        public function update(): void
+        {
+            $this->updateName(); // OK
+        }
+    }
+}
+
+
+
+namespace NamespaceVisibilityOnMethodExluceSubNamespace\SubNamespace {
+
+    use NamespaceVisibilityOnMethodExcludeSubNamespace\Person;
+    class AnotherPersonUpdater
+    {
+        public function update(Person $person): void
+        {
+            $person->updateName(); // ERROR - Subnamespace of NamespaceVisibilityOnMethod, which is not allowed
+        }
+    }
+}
+

--- a/tests/Rules/data/namespaceVisibility/namespaceVisibilityOnMethodForDifferentNamespace.php
+++ b/tests/Rules/data/namespaceVisibility/namespaceVisibilityOnMethodForDifferentNamespace.php
@@ -1,0 +1,32 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NamespaceVisibilityOnMethodForDifferentNamespace {
+
+    use DaveLiddament\PhpLanguageExtensions\NamespaceVisibility;
+
+    class Person
+    {
+        #[NamespaceVisibility(namespace: 'NamespaceVisibilityOnMethodDifferentNamespace')]
+        public function updateName(): void
+        {
+        }
+
+    }
+}
+
+
+
+namespace NamespaceVisibilityOnMethodDifferentNamespace {
+
+    use NamespaceVisibilityOnMethodForDifferentNamespace\Person;
+    class AnotherPersonUpdater
+    {
+        public function update(Person $person): void
+        {
+            $person->updateName(); // OK, call to Person::updateName from allowed namespace.
+        }
+    }
+}
+

--- a/tests/Rules/data/namespaceVisibility/namespaceVisibilityOnNew.php
+++ b/tests/Rules/data/namespaceVisibility/namespaceVisibilityOnNew.php
@@ -1,0 +1,57 @@
+<?php
+
+namespace NamespaceVisibilityOnNew {
+
+    use DaveLiddament\PhpLanguageExtensions\NamespaceVisibility;
+
+    #[NamespaceVisibility]
+    class Person
+    {
+        public static function create(): Person
+        {
+            return new Person(); // OK
+        }
+
+        public static function createSelf(): self
+        {
+            return new self(); // OK
+        }
+    }
+
+    class PersonBuilder
+    {
+        public function build(): Person
+        {
+            return new Person(); // OK
+        }
+    }
+
+    new Person(); // OK
+}
+
+namespace NamespaceVisibilityOnNew\SubNamespace {
+
+    use NamespaceVisibilityOnNew\Person;
+
+    class AnotherPersonBuilder
+    {
+        public function build(): Person
+        {
+            return new Person(); // OK - Subnamespace of NamespaceVisibilityOnMethod, which is allowed
+        }
+    }
+}
+
+
+namespace NamespaceVisibilityOnNew2 {
+
+    use NamespaceVisibilityOnNew\Person;
+
+    class Exam
+    {
+        public function addPerson(): void
+        {
+            new Person(); // ERROR
+        }
+    }
+}

--- a/tests/Rules/data/namespaceVisibility/namespaceVisibilityOnNewExcludeSubNamespaces.php
+++ b/tests/Rules/data/namespaceVisibility/namespaceVisibilityOnNewExcludeSubNamespaces.php
@@ -1,0 +1,43 @@
+<?php
+
+namespace NamespaceVisibilityOnNewExcludeSubNamespaces {
+
+    use DaveLiddament\PhpLanguageExtensions\NamespaceVisibility;
+
+    #[NamespaceVisibility(excludeSubNamespaces: true)]
+    class Person
+    {
+        public static function create(): Person
+        {
+            return new Person(); // OK
+        }
+
+        public static function createSelf(): self
+        {
+            return new self(); // OK
+        }
+    }
+
+    class PersonBuilder
+    {
+        public function build(): Person
+        {
+            return new Person(); // OK
+        }
+    }
+
+    new Person(); // OK
+}
+
+namespace NamespaceVisibilityOnNewExcludeSubNamespaces\SubNamespace {
+
+    use NamespaceVisibilityOnNewExcludeSubNamespaces\Person;
+
+    class AnotherPersonBuilder
+    {
+        public function build(): Person
+        {
+            return new Person(); // ERROR - Subnamespace of NamespaceVisibilityOnMethod not allowed
+        }
+    }
+}

--- a/tests/Rules/data/namespaceVisibility/namespaceVisibilityOnNewForDifferentNamespaces.php
+++ b/tests/Rules/data/namespaceVisibility/namespaceVisibilityOnNewForDifferentNamespaces.php
@@ -1,0 +1,26 @@
+<?php
+
+namespace NamespaceVisibilityOnNewForDifferentNamespaces {
+
+    use DaveLiddament\PhpLanguageExtensions\NamespaceVisibility;
+
+    #[NamespaceVisibility(namespace: 'NamespaceVisibilityOnNewForDifferentNamespaces2')]
+    class Person
+    {
+    }
+}
+
+
+
+namespace NamespaceVisibilityOnNewForDifferentNamespaces2 {
+
+    use NamespaceVisibilityOnNewForDifferentNamespaces\Person;
+
+    class Exam
+    {
+        public function addPerson(): void
+        {
+            new Person(); // OK
+        }
+    }
+}

--- a/tests/Rules/data/namespaceVisibility/namespaceVisibilityOnStaticMethod.php
+++ b/tests/Rules/data/namespaceVisibility/namespaceVisibilityOnStaticMethod.php
@@ -36,7 +36,7 @@ namespace NamespaceVisibilityOnStaticMethod\SubNamespace {
     {
         public function updater(): void
         {
-            Person::updateName(); // OK: Call to Person::updateName allowed as has namespace visibility and .
+            Person::updateName(); // OK: Call to Person::updateName allowed as has namespace visibility and is a sub-namespace of NamespaceVisibilityOnStaticMethod.
         }
     }
 }

--- a/tests/Rules/data/namespaceVisibility/namespaceVisibilityOnStaticMethod.php
+++ b/tests/Rules/data/namespaceVisibility/namespaceVisibilityOnStaticMethod.php
@@ -1,0 +1,55 @@
+<?php
+
+namespace NamespaceVisibilityOnStaticMethod {
+
+    use DaveLiddament\PhpLanguageExtensions\NamespaceVisibility;
+
+    class Person
+    {
+        #[NamespaceVisibility]
+        public static function updateName(): void
+        {
+        }
+
+        public static function update(): void
+        {
+            Person::updateName(); // OK: Calls to same class allowed.
+        }
+    }
+
+    class Updater
+    {
+        public function updater(): void
+        {
+            Person::updateName(); // OK: Call to Person::updateName allowed as has namespace  visibility.
+        }
+    }
+
+    Person::updateName(); // OK: Call to Person::updateName allowed as has namespace  visibility.
+}
+
+namespace NamespaceVisibilityOnStaticMethod\SubNamespace {
+
+    use NamespaceVisibilityOnStaticMethod\Person;
+
+    class Updater
+    {
+        public function updater(): void
+        {
+            Person::updateName(); // OK: Call to Person::updateName allowed as has namespace visibility and .
+        }
+    }
+}
+
+namespace NamespaceVisibilityOnStaticMethod2 {
+
+    use NamespaceVisibilityOnStaticMethod\Person;
+
+    class AnotherUpdater
+    {
+        public function update(): void
+        {
+            Person::updateName(); // ERROR: Call to Person::updateName which has namespaceVisibility visibility
+        }
+    }
+}

--- a/tests/Rules/data/namespaceVisibility/namespaceVisibilityOnStaticMethodExcludeSubNamespaces.php
+++ b/tests/Rules/data/namespaceVisibility/namespaceVisibilityOnStaticMethodExcludeSubNamespaces.php
@@ -1,0 +1,29 @@
+<?php
+
+namespace NamespaceVisibilityOnStaticMethodExcludeSubNamespaces {
+
+    use DaveLiddament\PhpLanguageExtensions\NamespaceVisibility;
+
+    class Person
+    {
+        #[NamespaceVisibility(excludeSubNamespaces: true)]
+        public static function updateName(): void
+        {
+        }
+
+    }
+
+}
+
+namespace NamespaceVisibilityOnStaticMethodExcludeSubNamespaces\SubNamespace {
+
+    use NamespaceVisibilityOnStaticMethodExcludeSubNamespaces\Person;
+
+    class Updater
+    {
+        public function updater(): void
+        {
+            Person::updateName(); // ERROR: Call to Person::updateName NOT allowed as sub namespace not allowed.
+        }
+    }
+}

--- a/tests/Rules/data/namespaceVisibility/namespaceVisibilityOnStaticMethodForDifferentNamespaces.php
+++ b/tests/Rules/data/namespaceVisibility/namespaceVisibilityOnStaticMethodForDifferentNamespaces.php
@@ -1,0 +1,29 @@
+<?php
+
+namespace NamespaceVisibilityOnStaticMethodForDifferentNamespaces {
+
+    use DaveLiddament\PhpLanguageExtensions\NamespaceVisibility;
+
+    class Person
+    {
+        #[NamespaceVisibility(namespace: 'NamespaceVisibilityOnStaticMethodDifferentNamespaces')]
+        public static function updateName(): void
+        {
+        }
+
+    }
+
+}
+
+namespace NamespaceVisibilityOnStaticMethodDifferentNamespaces {
+
+    use NamespaceVisibilityOnStaticMethodForDifferentNamespaces\Person;
+
+    class Updater
+    {
+        public function updater(): void
+        {
+            Person::updateName(); // OK. Call to Person::updateName allowed from given namespace.
+        }
+    }
+}

--- a/tests/Rules/data/namespaceVisibility/namespaceVisibilityRulesIgnoredForTestClass.php
+++ b/tests/Rules/data/namespaceVisibility/namespaceVisibilityRulesIgnoredForTestClass.php
@@ -1,0 +1,31 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NamespaceVisibilityRulesIgnoredForTestClass {
+
+    use DaveLiddament\PhpLanguageExtensions\NamespaceVisibility;
+
+
+    #[NamespaceVisibility]
+    class Person
+    {
+        public function updateName(): void
+        {
+        }
+    }
+}
+
+namespace NamespaceVisibilityRulesIgnoredForTestClass\Person {
+
+    use NamespaceVisibilityRulesIgnoredForTestClass\Person;
+
+    class PersonTest
+    {
+        public function updater(Person $person): void
+        {
+            $person->updateName(); // OK: calling from a class with a name ending Test
+        }
+    }
+
+}

--- a/tests/Rules/data/namespaceVisibility/namespaceVisibilityRulesIgnoredForTestNamespace.php
+++ b/tests/Rules/data/namespaceVisibility/namespaceVisibilityRulesIgnoredForTestNamespace.php
@@ -1,0 +1,33 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NamespaceVisibilityRulesIgnoredForTestNamespace {
+
+
+    use DaveLiddament\PhpLanguageExtensions\NamespaceVisibility;
+
+    #[NamespaceVisibility]
+    class Person
+    {
+        public function updateName(): void
+        {
+        }
+    }
+
+}
+
+
+namespace NamespaceVisibilityRulesIgnoredForTestNamespace\Test\Person {
+
+    use NamespaceVisibilityRulesIgnoredForTestNamespace\Person;
+
+    class PersonCheck
+    {
+        public function updater(Person $person): void
+        {
+            $person->updateName(); // OK: calling from a test namespace
+        }
+    }
+
+}

--- a/tests/Rules/data/sealed/sealedClasses.php
+++ b/tests/Rules/data/sealed/sealedClasses.php
@@ -1,0 +1,25 @@
+<?php
+
+declare(strict_types=1);
+
+namespace SealedClasses;
+
+use DaveLiddament\PhpLanguageExtensions\Sealed;
+
+class Success extends Response // OK
+{
+}
+
+class Failed extends Response // OK
+{
+}
+
+#[Sealed(Success::class, Failed::class)]
+class Response
+{
+}
+
+
+class AnotherClass extends Response // ERROR AnotherClass can not extend Response
+{
+}

--- a/tests/Rules/data/sealed/sealedInterfaces.php
+++ b/tests/Rules/data/sealed/sealedInterfaces.php
@@ -1,0 +1,25 @@
+<?php
+
+declare(strict_types=1);
+
+namespace SealedInterfaces;
+
+use DaveLiddament\PhpLanguageExtensions\Sealed;
+
+class Success implements Response // OK
+{
+}
+
+class Failed implements Response // OK
+{
+}
+
+#[Sealed(Success::class, Failed::class)]
+interface Response
+{
+}
+
+
+class AnotherClass implements Response // ERROR AnotherClass can not implement Response
+{
+}

--- a/tests/Unit/AttributeValueReaderTest.php
+++ b/tests/Unit/AttributeValueReaderTest.php
@@ -16,12 +16,12 @@ use PHPUnit\Framework\TestCase;
 
 class AttributeValueReaderTest extends TestCase
 {
-    /** @return array<int,array{string, array<int,class-string>}> */
+    /** @return array<int,array{string, array<int,class-string>|null}> */
     public function methodDataProvider(): array
     {
         return [
-            ['noAttribute', []],
-            ['__construct', []],
+            ['noAttribute', null],
+            ['__construct', null],
             ['friendWithOneValue', [Foo::class]],
             ['friendWithTwoValues', [Foo::class, Bar::class]],
             ['friendWithOneValueInArray', [Bar::class]],
@@ -33,7 +33,7 @@ class AttributeValueReaderTest extends TestCase
      *
      * @param array<int,class-string> $expectedValues
      */
-    public function testGettingMethodAttributeValues(string $methodName, array $expectedValues): void
+    public function testGettingMethodAttributeValues(string $methodName, ?array $expectedValues): void
     {
         $actualValues = AttributeValueReader::getAttributeValuesForMethod(
             new \ReflectionClass(MethodAttributes::class),
@@ -44,11 +44,11 @@ class AttributeValueReaderTest extends TestCase
         $this->assertEquals($expectedValues, $actualValues);
     }
 
-    /** @return array<int,array{class-string, array<int,class-string>}> */
+    /** @return array<int,array{class-string, array<int,class-string>|null}> */
     public function classDataProvider(): array
     {
         return [
-            [Class0Friends::class, []],
+            [Class0Friends::class, null],
             [Class1Friend::class, [Foo::class]],
             [Class2Friends::class, [Foo::class, Bar::class]],
         ];
@@ -58,9 +58,9 @@ class AttributeValueReaderTest extends TestCase
      * @dataProvider classDataProvider
      *
      * @param class-string $class
-     * @param array<int,class-string> $expectedValues
+     * @param array<int,class-string>|null $expectedValues
      */
-    public function testGettingClassAttributeValues(string $class, array $expectedValues): void
+    public function testGettingClassAttributeValues(string $class, ?array $expectedValues): void
     {
         $actualValues = AttributeValueReader::getAttributeValuesForClass(
             new \ReflectionClass($class),

--- a/tests/Unit/NamespaceVisibilityOptionsParserTest.php
+++ b/tests/Unit/NamespaceVisibilityOptionsParserTest.php
@@ -1,0 +1,82 @@
+<?php
+
+declare(strict_types=1);
+
+namespace DaveLiddament\PhpstanPhpLanguageExtensions\Tests\Unit;
+
+use DaveLiddament\PhpstanPhpLanguageExtensions\Rules\NamespaceVisibilitySettingsParser;
+use DaveLiddament\PhpstanPhpLanguageExtensions\Tests\Unit\data\NamespaceVisibilityBothArguments;
+use DaveLiddament\PhpstanPhpLanguageExtensions\Tests\Unit\data\NamespaceVisibilityBothNamedArguments;
+use DaveLiddament\PhpstanPhpLanguageExtensions\Tests\Unit\data\NamespaceVisibilityFirstArgument;
+use DaveLiddament\PhpstanPhpLanguageExtensions\Tests\Unit\data\NamespaceVisibilityNamedExcludeSubNamespacesArgument;
+use DaveLiddament\PhpstanPhpLanguageExtensions\Tests\Unit\data\NamespaceVisibilityNamedNamespaceArgument;
+use DaveLiddament\PhpstanPhpLanguageExtensions\Tests\Unit\data\NamespaceVisibilityNoArguments;
+use DaveLiddament\PhpstanPhpLanguageExtensions\Tests\Unit\data\NoNamespaceVisibilityAttribute;
+use PHPUnit\Framework\TestCase;
+
+class NamespaceVisibilityOptionsParserTest extends TestCase
+{
+    private const OVERRIDDEN_VALUE = 'foo/bar';
+    private const NON_OVERRIDDEN_NAMESPACE = 'DaveLiddament\PhpstanPhpLanguageExtensions\Tests\Unit\data';
+
+    /** @return array<array-key, array{class-string, ?string, bool}> */
+    public function dataProvider(): array
+    {
+        return [
+            [
+                NamespaceVisibilityBothArguments::class,
+                self::OVERRIDDEN_VALUE,
+                true,
+            ],
+            [
+                NamespaceVisibilityBothNamedArguments::class,
+                self::OVERRIDDEN_VALUE,
+                true,
+            ],
+            [
+                NamespaceVisibilityFirstArgument::class,
+                self::OVERRIDDEN_VALUE,
+                false,
+            ],
+            [
+                NamespaceVisibilityNamedExcludeSubNamespacesArgument::class,
+                self::NON_OVERRIDDEN_NAMESPACE,
+                true,
+            ],
+            [
+                NamespaceVisibilityNamedNamespaceArgument::class,
+                self::OVERRIDDEN_VALUE,
+                false,
+            ],
+            [
+                NamespaceVisibilityNoArguments::class,
+                self::NON_OVERRIDDEN_NAMESPACE,
+                false,
+            ],
+        ];
+    }
+
+    /**
+     * @dataProvider dataProvider
+     *
+     * @param class-string $class
+     */
+    public function testParsingNamespaceVisibilityOptions(
+        string $class,
+        ?string $expectedNamespace,
+        bool $expectedExcludeSubNamespaces,
+    ): void {
+        $reflectionClass = new \ReflectionClass($class);
+        $namespaceVisibilitySettings = NamespaceVisibilitySettingsParser::getValuesFromClass($reflectionClass);
+        $this->assertTrue($namespaceVisibilitySettings->hasNamespaceAttribute());
+        $this->assertSame($expectedNamespace, $namespaceVisibilitySettings->getNamespace());
+        $this->assertSame($expectedExcludeSubNamespaces, $namespaceVisibilitySettings->isExcludeSubNamespaces());
+    }
+
+    public function testNoNamespaceVisibilityAttribute(): void
+    {
+        $reflectionClass = new \ReflectionClass(NoNamespaceVisibilityAttribute::class);
+        $namespaceVisibilitySettings = NamespaceVisibilitySettingsParser::getValuesFromClass($reflectionClass);
+        $this->assertFalse($namespaceVisibilitySettings->hasNamespaceAttribute());
+    }
+}

--- a/tests/Unit/SubNamespaceCheckerTest.php
+++ b/tests/Unit/SubNamespaceCheckerTest.php
@@ -2,36 +2,33 @@
 
 declare(strict_types=1);
 
-
 namespace DaveLiddament\PhpstanPhpLanguageExtensions\Tests\Unit;
-
 
 use DaveLiddament\PhpstanPhpLanguageExtensions\Helpers\SubNamespaceChecker;
 use PHPUnit\Framework\TestCase;
 
 class SubNamespaceCheckerTest extends TestCase
 {
-
     /** @return array<array-key, array{bool, string, string}> */
     public function dataProvider(): array
     {
         return [
-            "same namespace" => [
+            'same namespace' => [
                 true,
                 'Foo\Bar',
                 'Foo\Bar',
             ],
-            "different namespace" => [
+            'different namespace' => [
                 false,
                 'Foo\Bar',
                 'Foo\Baz',
             ],
-            "sub namespace" => [
+            'sub namespace' => [
                 true,
                 'Foo\Bar\Baz',
                 'Foo\Bar',
             ],
-            "not sub namespace 1" => [
+            'not sub namespace 1' => [
                 false,
                 'Foo\Bart',
                 'Foo\Bar',
@@ -40,10 +37,9 @@ class SubNamespaceCheckerTest extends TestCase
     }
 
     /** @dataProvider dataProvider */
-    public function testSubNamespaceChecker(bool $expected, string $namespace, $namespaceToCheckAgainst): void
+    public function testSubNamespaceChecker(bool $expected, string $namespace, string $namespaceToCheckAgainst): void
     {
         $actual = SubNamespaceChecker::isSubNamespace($namespace, $namespaceToCheckAgainst);
         $this->assertSame($expected, $actual);
     }
 }
-

--- a/tests/Unit/SubNamespaceCheckerTest.php
+++ b/tests/Unit/SubNamespaceCheckerTest.php
@@ -1,0 +1,49 @@
+<?php
+
+declare(strict_types=1);
+
+
+namespace DaveLiddament\PhpstanPhpLanguageExtensions\Tests\Unit;
+
+
+use DaveLiddament\PhpstanPhpLanguageExtensions\Helpers\SubNamespaceChecker;
+use PHPUnit\Framework\TestCase;
+
+class SubNamespaceCheckerTest extends TestCase
+{
+
+    /** @return array<array-key, array{bool, string, string}> */
+    public function dataProvider(): array
+    {
+        return [
+            "same namespace" => [
+                true,
+                'Foo\Bar',
+                'Foo\Bar',
+            ],
+            "different namespace" => [
+                false,
+                'Foo\Bar',
+                'Foo\Baz',
+            ],
+            "sub namespace" => [
+                true,
+                'Foo\Bar\Baz',
+                'Foo\Bar',
+            ],
+            "not sub namespace 1" => [
+                false,
+                'Foo\Bart',
+                'Foo\Bar',
+            ],
+        ];
+    }
+
+    /** @dataProvider dataProvider */
+    public function testSubNamespaceChecker(bool $expected, string $namespace, $namespaceToCheckAgainst): void
+    {
+        $actual = SubNamespaceChecker::isSubNamespace($namespace, $namespaceToCheckAgainst);
+        $this->assertSame($expected, $actual);
+    }
+}
+

--- a/tests/Unit/data/NamespaceVisibilityBothArguments.php
+++ b/tests/Unit/data/NamespaceVisibilityBothArguments.php
@@ -1,0 +1,10 @@
+<?php
+
+namespace DaveLiddament\PhpstanPhpLanguageExtensions\Tests\Unit\data;
+
+use DaveLiddament\PhpLanguageExtensions\NamespaceVisibility;
+
+#[NamespaceVisibility('foo/bar', true)]
+class NamespaceVisibilityBothArguments
+{
+}

--- a/tests/Unit/data/NamespaceVisibilityBothNamedArguments.php
+++ b/tests/Unit/data/NamespaceVisibilityBothNamedArguments.php
@@ -1,0 +1,10 @@
+<?php
+
+namespace DaveLiddament\PhpstanPhpLanguageExtensions\Tests\Unit\data;
+
+use DaveLiddament\PhpLanguageExtensions\NamespaceVisibility;
+
+#[NamespaceVisibility(namespace: 'foo/bar', excludeSubNamespaces: true)]
+class NamespaceVisibilityBothNamedArguments
+{
+}

--- a/tests/Unit/data/NamespaceVisibilityFirstArgument.php
+++ b/tests/Unit/data/NamespaceVisibilityFirstArgument.php
@@ -1,0 +1,10 @@
+<?php
+
+namespace DaveLiddament\PhpstanPhpLanguageExtensions\Tests\Unit\data;
+
+use DaveLiddament\PhpLanguageExtensions\NamespaceVisibility;
+
+#[NamespaceVisibility('foo/bar')]
+class NamespaceVisibilityFirstArgument
+{
+}

--- a/tests/Unit/data/NamespaceVisibilityNamedExcludeSubNamespacesArgument.php
+++ b/tests/Unit/data/NamespaceVisibilityNamedExcludeSubNamespacesArgument.php
@@ -1,0 +1,10 @@
+<?php
+
+namespace DaveLiddament\PhpstanPhpLanguageExtensions\Tests\Unit\data;
+
+use DaveLiddament\PhpLanguageExtensions\NamespaceVisibility;
+
+#[NamespaceVisibility(excludeSubNamespaces: true)]
+class NamespaceVisibilityNamedExcludeSubNamespacesArgument
+{
+}

--- a/tests/Unit/data/NamespaceVisibilityNamedNamespaceArgument.php
+++ b/tests/Unit/data/NamespaceVisibilityNamedNamespaceArgument.php
@@ -1,0 +1,10 @@
+<?php
+
+namespace DaveLiddament\PhpstanPhpLanguageExtensions\Tests\Unit\data;
+
+use DaveLiddament\PhpLanguageExtensions\NamespaceVisibility;
+
+#[NamespaceVisibility(namespace: 'foo/bar')]
+class NamespaceVisibilityNamedNamespaceArgument
+{
+}

--- a/tests/Unit/data/NamespaceVisibilityNoArguments.php
+++ b/tests/Unit/data/NamespaceVisibilityNoArguments.php
@@ -1,0 +1,10 @@
+<?php
+
+namespace DaveLiddament\PhpstanPhpLanguageExtensions\Tests\Unit\data;
+
+use DaveLiddament\PhpLanguageExtensions\NamespaceVisibility;
+
+#[NamespaceVisibility]
+class NamespaceVisibilityNoArguments
+{
+}

--- a/tests/Unit/data/NoNamespaceVisibilityAttribute.php
+++ b/tests/Unit/data/NoNamespaceVisibilityAttribute.php
@@ -1,0 +1,7 @@
+<?php
+
+namespace DaveLiddament\PhpstanPhpLanguageExtensions\Tests\Unit\data;
+
+class NoNamespaceVisibilityAttribute
+{
+}


### PR DESCRIPTION
Mirrors work done in https://github.com/DaveLiddament/php-language-extensions/pull/8

Adds attributes:
- `CallableFrom`
- `NamespaceVisibility`

Deprecates:
- `Friend` (replace with `CallableFrom`)
- `Package` (use `NamespaceVisibility`)