### PR TITLE
allow installing with phpstan/phpstan 2.0

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -5,7 +5,7 @@
   "type": "phpstan-extension",
   "require": {
     "php": "~8.0.0 || ~8.1.0 || ~8.2.0 || ~8.3.0 || ~8.4.0",
-    "phpstan/phpstan": "^1.12",
+    "phpstan/phpstan": "^1.12 || ^2.0",
     "dave-liddament/php-language-extensions": "^0.8.0 || ^0.9.0"
   },
   "require-dev": {

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "d2c9f53699076801cd1dd8e7b8f84e79",
+    "content-hash": "fc96e1b1b52327cb97d1c9f1dada6a29",
     "packages": [
         {
             "name": "dave-liddament/php-language-extensions",
@@ -59,16 +59,16 @@
         },
         {
             "name": "phpstan/phpstan",
-            "version": "1.12.7",
+            "version": "1.12.9",
             "source": {
                 "type": "git",
                 "url": "https://github.com/phpstan/phpstan.git",
-                "reference": "dc2b9976bd8b0f84ec9b0e50cc35378551de7af0"
+                "reference": "ceb937fb39a92deabc02d20709cf14b2c452502c"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/phpstan/phpstan/zipball/dc2b9976bd8b0f84ec9b0e50cc35378551de7af0",
-                "reference": "dc2b9976bd8b0f84ec9b0e50cc35378551de7af0",
+                "url": "https://api.github.com/repos/phpstan/phpstan/zipball/ceb937fb39a92deabc02d20709cf14b2c452502c",
+                "reference": "ceb937fb39a92deabc02d20709cf14b2c452502c",
                 "shasum": ""
             },
             "require": {
@@ -113,7 +113,7 @@
                     "type": "github"
                 }
             ],
-            "time": "2024-10-18T11:12:07+00:00"
+            "time": "2024-11-10T17:10:04+00:00"
         }
     ],
     "packages-dev": [


### PR DESCRIPTION
Allows installing with phpstan 2.0, which is released today.

Ran the ci tools configured in composer.json under php 8.3 and it did not give me any issues.

@DaveLiddament If you can merge and tag this, users depending on this library can also start using phpstan 2.0. Thank you!