### PR TITLE
fix: require phpstan v2

### DIFF
--- a/build/PHPStan/Rules/CheckRuleIsInExtension.php
+++ b/build/PHPStan/Rules/CheckRuleIsInExtension.php
@@ -23,6 +23,9 @@ final class CheckRuleIsInExtension implements Rule
             throw new \Exception('Expecting neon file to be parseable');
         }
 
+        /**
+         * @var array<array{class?: string}> $services
+         */
         $services = $file['services'] ?? [];
 
         $classes = [];
@@ -68,7 +71,9 @@ final class CheckRuleIsInExtension implements Rule
         }
 
         return [
-            RuleErrorBuilder::message("Rule [$className] not in extension.neon.")->build(),
+            RuleErrorBuilder::message("Rule [$className] not in extension.neon.")
+                ->identifier('phpExtensionLibrary.ruleIsInExtension')
+                ->build(),
         ];
     }
 }

--- a/composer.json
+++ b/composer.json
@@ -5,14 +5,14 @@
   "type": "phpstan-extension",
   "require": {
     "php": "~8.0.0 || ~8.1.0 || ~8.2.0 || ~8.3.0 || ~8.4.0",
-    "phpstan/phpstan": "^1.12 || ^2.0",
+    "phpstan/phpstan": "^2.0",
     "dave-liddament/php-language-extensions": "^0.8.0 || ^0.9.0"
   },
   "require-dev": {
     "phpunit/phpunit": "^9.6.12",
     "friendsofphp/php-cs-fixer": "^3.26.1",
     "php-parallel-lint/php-parallel-lint": "^1.3.2",
-    "dave-liddament/phpstan-rule-test-helper": "^0.4.0",
+    "dave-liddament/phpstan-rule-test-helper": "dev-phpstan-v2 as 0.5.0",
     "nette/neon": "^3.4"
   },
   "license": "MIT",
@@ -30,6 +30,12 @@
       "tests/Rules/data"
     ]
   },
+  "repositories": [
+    {
+      "type": "vcs",
+      "url": "https://github.com/simPod/phpstan-rule-test-helper"
+    }
+  ],
   "authors": [
     {
       "name": "Dave Liddament",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "fc96e1b1b52327cb97d1c9f1dada6a29",
+    "content-hash": "4b908a5a780e635c5ad5777a6de7b293",
     "packages": [
         {
             "name": "dave-liddament/php-language-extensions",
@@ -59,20 +59,20 @@
         },
         {
             "name": "phpstan/phpstan",
-            "version": "1.12.9",
+            "version": "2.0.3",
             "source": {
                 "type": "git",
                 "url": "https://github.com/phpstan/phpstan.git",
-                "reference": "ceb937fb39a92deabc02d20709cf14b2c452502c"
+                "reference": "46b4d3529b12178112d9008337beda0cc2a1a6b4"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/phpstan/phpstan/zipball/ceb937fb39a92deabc02d20709cf14b2c452502c",
-                "reference": "ceb937fb39a92deabc02d20709cf14b2c452502c",
+                "url": "https://api.github.com/repos/phpstan/phpstan/zipball/46b4d3529b12178112d9008337beda0cc2a1a6b4",
+                "reference": "46b4d3529b12178112d9008337beda0cc2a1a6b4",
                 "shasum": ""
             },
             "require": {
-                "php": "^7.2|^8.0"
+                "php": "^7.4|^8.0"
             },
             "conflict": {
                 "phpstan/phpstan-shim": "*"
@@ -113,7 +113,7 @@
                     "type": "github"
                 }
             ],
-            "time": "2024-11-10T17:10:04+00:00"
+            "time": "2024-11-28T22:19:37+00:00"
         }
     ],
     "packages-dev": [
@@ -409,21 +409,21 @@
         },
         {
             "name": "dave-liddament/phpstan-rule-test-helper",
-            "version": "0.4.0",
+            "version": "dev-phpstan-v2",
             "source": {
                 "type": "git",
-                "url": "https://github.com/DaveLiddament/phpstan-rule-test-helper.git",
-                "reference": "137e895ab049b22c11b55354eb8fc9261e9fa0ad"
+                "url": "https://github.com/simPod/phpstan-rule-test-helper.git",
+                "reference": "1ea2f22577b8afca0df2d8e4bf46f910e698aa1c"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/DaveLiddament/phpstan-rule-test-helper/zipball/137e895ab049b22c11b55354eb8fc9261e9fa0ad",
-                "reference": "137e895ab049b22c11b55354eb8fc9261e9fa0ad",
+                "url": "https://api.github.com/repos/simPod/phpstan-rule-test-helper/zipball/1ea2f22577b8afca0df2d8e4bf46f910e698aa1c",
+                "reference": "1ea2f22577b8afca0df2d8e4bf46f910e698aa1c",
                 "shasum": ""
             },
             "require": {
                 "php": "~8.0.0 || ~8.1.0 || ~8.2.0 || ~8.3.0 || ~8.4.0",
-                "phpstan/phpstan": "^1.6"
+                "phpstan/phpstan": "^2.0"
             },
             "require-dev": {
                 "friendsofphp/php-cs-fixer": "^3.7",
@@ -436,7 +436,39 @@
                     "DaveLiddament\\PhpstanRuleTestHelper\\": "src/"
                 }
             },
-            "notification-url": "https://packagist.org/downloads/",
+            "autoload-dev": {
+                "psr-4": {
+                    "DaveLiddament\\PhpstanRuleTestHelper\\Tests\\": "tests/"
+                }
+            },
+            "scripts": {
+                "composer-validate": [
+                    "@composer validate --no-check-all --strict"
+                ],
+                "cs-fix": [
+                    "php-cs-fixer fix"
+                ],
+                "cs": [
+                    "@putenv PHP_CS_FIXER_IGNORE_ENV=1",
+                    "php-cs-fixer fix --dry-run -v"
+                ],
+                "analyse": [
+                    "phpstan analyse"
+                ],
+                "lint": [
+                    "parallel-lint src tests"
+                ],
+                "test": [
+                    "phpunit"
+                ],
+                "ci": [
+                    "@composer-validate",
+                    "@lint",
+                    "@cs",
+                    "@test",
+                    "@analyse"
+                ]
+            },
             "license": [
                 "MIT"
             ],
@@ -448,10 +480,9 @@
             ],
             "description": "Library to help make testing of PHPStan rules easier",
             "support": {
-                "issues": "https://github.com/DaveLiddament/phpstan-rule-test-helper/issues",
-                "source": "https://github.com/DaveLiddament/phpstan-rule-test-helper/tree/0.4.0"
+                "source": "https://github.com/simPod/phpstan-rule-test-helper/tree/phpstan-v2"
             },
-            "time": "2024-10-26T13:34:00+00:00"
+            "time": "2024-12-02T17:12:42+00:00"
         },
         {
             "name": "doctrine/instantiator",
@@ -4497,9 +4528,18 @@
             "time": "2024-03-03T12:36:25+00:00"
         }
     ],
-    "aliases": [],
+    "aliases": [
+        {
+            "package": "dave-liddament/phpstan-rule-test-helper",
+            "version": "dev-phpstan-v2",
+            "alias": "0.5.0",
+            "alias_normalized": "0.5.0.0"
+        }
+    ],
     "minimum-stability": "stable",
-    "stability-flags": {},
+    "stability-flags": {
+        "dave-liddament/phpstan-rule-test-helper": 20
+    },
     "prefer-stable": false,
     "prefer-lowest": false,
     "platform": {

--- a/e2e/PHPStanResultsChecker.php
+++ b/e2e/PHPStanResultsChecker.php
@@ -21,6 +21,7 @@ final class PHPStanResultsChecker
         $totals = $asJson['totals'] ?? null;
         $this->assertArray($totals, 'Failed to find totals in PHPStan results');
 
+        /** @var int|null $errorCount */
         $errorCount = $totals['errors'] ?? null;
         $this->assertNotNull($errorCount, 'Failed to find error count in PHPStan results');
         if ((int) $errorCount > 0) {
@@ -40,6 +41,7 @@ final class PHPStanResultsChecker
             $messages = $fileIssues['messages'] ?? null;
             $this->assertArray($messages, 'Failed to find messages in PHPStan results');
 
+            /** @var array{identifier?: string, line?: int} $issue */
             foreach ($messages as $issue) {
                 $line = $issue['line'] ?? null;
                 $identifier = $issue['identifier'] ?? '';
@@ -63,7 +65,7 @@ final class PHPStanResultsChecker
 
         $errorMessage = implode("\n", [
             'Additional reported errors:',
-            var_export(array_values($additionalReportedErrors), true),
+            var_export($additionalReportedErrors, true),
             'Expected errors not reported:',
             var_export(array_values($expectedResults), true),
         ]);
@@ -79,7 +81,7 @@ final class PHPStanResultsChecker
         }
     }
 
-    /** @phpstan-assert array $value  */
+    /** @phpstan-assert array<mixed> $value  */
     private function assertArray(mixed $value, string $error): void
     {
         if (!is_array($value)) {

--- a/e2e/data/FriendProblems.php
+++ b/e2e/data/FriendProblems.php
@@ -6,7 +6,7 @@ class FriendProblems
 {
     public function badCode(Person $person): void
     {
-        new Person();
+        new Person(); /** @phpstan-ignore new.resultUnused */
         Person::aStaticMethod();
         $person->aMethod();
     }

--- a/src/Helpers/AttributeValueReader.php
+++ b/src/Helpers/AttributeValueReader.php
@@ -23,7 +23,10 @@ class AttributeValueReader
         $reflectionMethod = $reflectionClass->getMethod($methodName);
 
         foreach ($reflectionMethod->getAttributes($attributeClassName) as $attribute) {
-            return $attribute->getArguments();
+            /** @var array<int, string> $arguments */
+            $arguments = $attribute->getArguments();
+
+            return $arguments;
         }
 
         return [];
@@ -40,7 +43,10 @@ class AttributeValueReader
         string $attributeClassName,
     ): array {
         foreach ($reflectionClass->getAttributes($attributeClassName) as $attribute) {
-            return $attribute->getArguments();
+            /** @var array<int, string> $arguments */
+            $arguments = $attribute->getArguments();
+
+            return $arguments;
         }
 
         return [];

--- a/src/Rules/AbstractFriendRule.php
+++ b/src/Rules/AbstractFriendRule.php
@@ -11,8 +11,8 @@ use DaveLiddament\PhpstanPhpLanguageExtensions\Helpers\Cache;
 use DaveLiddament\PhpstanPhpLanguageExtensions\Helpers\TestClassChecker;
 use PHPStan\Analyser\Scope;
 use PHPStan\Reflection\ReflectionProvider;
+use PHPStan\Rules\IdentifierRuleError;
 use PHPStan\Rules\Rule;
-use PHPStan\Rules\RuleError;
 use PHPStan\Rules\RuleErrorBuilder;
 
 /**
@@ -40,7 +40,7 @@ abstract class AbstractFriendRule implements Rule
         Scope $scope,
         string $class,
         string $methodName,
-    ): ?RuleError {
+    ): ?IdentifierRuleError {
         $callingClass = $scope->getClassReflection()?->getName();
         $classReflection = $this->reflectionProvider->getClass($class);
         $className = $classReflection->getName();

--- a/src/Rules/AbstractNamespaceVisibilityRule.php
+++ b/src/Rules/AbstractNamespaceVisibilityRule.php
@@ -13,8 +13,8 @@ use DaveLiddament\PhpstanPhpLanguageExtensions\Helpers\SubNamespaceChecker;
 use DaveLiddament\PhpstanPhpLanguageExtensions\Helpers\TestClassChecker;
 use PHPStan\Analyser\Scope;
 use PHPStan\Reflection\ReflectionProvider;
+use PHPStan\Rules\IdentifierRuleError;
 use PHPStan\Rules\Rule;
-use PHPStan\Rules\RuleError;
 use PHPStan\Rules\RuleErrorBuilder;
 
 /**
@@ -42,7 +42,7 @@ abstract class AbstractNamespaceVisibilityRule implements Rule
         Scope $scope,
         string $class,
         string $methodName,
-    ): ?RuleError {
+    ): ?IdentifierRuleError {
         $classReflection = $this->reflectionProvider->getClass($class);
         $className = $classReflection->getName();
         $nativeReflection = $classReflection->getNativeReflection();

--- a/src/Rules/AbstractPackageRule.php
+++ b/src/Rules/AbstractPackageRule.php
@@ -10,8 +10,8 @@ use DaveLiddament\PhpstanPhpLanguageExtensions\Helpers\Cache;
 use DaveLiddament\PhpstanPhpLanguageExtensions\Helpers\TestClassChecker;
 use PHPStan\Analyser\Scope;
 use PHPStan\Reflection\ReflectionProvider;
+use PHPStan\Rules\IdentifierRuleError;
 use PHPStan\Rules\Rule;
-use PHPStan\Rules\RuleError;
 use PHPStan\Rules\RuleErrorBuilder;
 
 /**
@@ -39,7 +39,7 @@ abstract class AbstractPackageRule implements Rule
         Scope $scope,
         string $class,
         string $methodName,
-    ): ?RuleError {
+    ): ?IdentifierRuleError {
         $classReflection = $this->reflectionProvider->getClass($class);
         $className = $classReflection->getName();
         $nativeReflection = $classReflection->getNativeReflection();

--- a/src/Rules/AbstractTestTagRule.php
+++ b/src/Rules/AbstractTestTagRule.php
@@ -10,8 +10,8 @@ use DaveLiddament\PhpstanPhpLanguageExtensions\Helpers\Cache;
 use DaveLiddament\PhpstanPhpLanguageExtensions\Helpers\TestClassChecker;
 use PHPStan\Analyser\Scope;
 use PHPStan\Reflection\ReflectionProvider;
+use PHPStan\Rules\IdentifierRuleError;
 use PHPStan\Rules\Rule;
-use PHPStan\Rules\RuleError;
 use PHPStan\Rules\RuleErrorBuilder;
 
 /**
@@ -39,7 +39,7 @@ abstract class AbstractTestTagRule implements Rule
         Scope $scope,
         string $class,
         string $methodName,
-    ): ?RuleError {
+    ): ?IdentifierRuleError {
         $callingClass = $scope->getClassReflection()?->getName();
 
         $classReflection = $this->reflectionProvider->getClass($class);

--- a/src/Rules/InjectableVersionRule.php
+++ b/src/Rules/InjectableVersionRule.php
@@ -14,7 +14,6 @@ use PHPStan\Analyser\Scope;
 use PHPStan\Node\InClassMethodNode;
 use PHPStan\Reflection\ClassReflection;
 use PHPStan\Reflection\MethodReflection;
-use PHPStan\Reflection\ParametersAcceptorSelector;
 use PHPStan\Reflection\ReflectionProvider;
 use PHPStan\Rules\Rule;
 use PHPStan\Rules\RuleErrorBuilder;
@@ -62,9 +61,7 @@ class InjectableVersionRule implements Rule
             return [];
         }
 
-        $parameters = ParametersAcceptorSelector::selectSingle($method->getVariants());
-
-        foreach ($parameters->getParameters() as $index => $parameter) {
+        foreach ($method->getParameters() as $index => $parameter) {
             $position = $index + 1;
 
             $type = $parameter->getType();


### PR DESCRIPTION
Extension is broken on phpstan v2 since it has not been properly handled in https://github.com/DaveLiddament/phpstan-php-language-extensions/pull/33

See https://github.com/phpstan/phpstan/issues/12096

Rule test helper adapted in https://github.com/DaveLiddament/phpstan-rule-test-helper/pull/7