### PR TITLE
Fix min PHPStan requirement

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -5,7 +5,7 @@
   "type": "phpstan-extension",
   "require": {
     "php": "~8.0.0 || ~8.1.0 || ~8.2.0 || ~8.3.0 || ~8.4.0",
-    "phpstan/phpstan": "^1.12.19 || ^2.0",
+    "phpstan/phpstan": "^1.12.15 || ^2.0",
     "dave-liddament/php-language-extensions": "^0.8.0 || ^0.9.0"
   },
   "require-dev": {


### PR DESCRIPTION
Version `1.12.19` does not currently exist. I think this might be a typo from  `1.12.9`, but becuase I am not sure of this, I just require the current latests `1.12.*` version